### PR TITLE
Unify header navigation across all pages

### DIFF
--- a/docs/biography.html
+++ b/docs/biography.html
@@ -245,9 +245,9 @@
         sciClaw
       </a>
       <nav class="nav-links">
-        <a class="util" href="index.html">Home</a>
-        <a class="util" href="docs.html">Documentation</a>
+        <a class="util" href="docs.html">Docs</a>
         <a class="util" href="philosophy.html">Philosophy</a>
+        <a class="util active" href="biography.html">Creator</a>
         <a class="util" href="https://github.com/drpedapati/sciclaw" target="_blank" rel="noopener noreferrer">GitHub</a>
       </nav>
     </header>

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -486,15 +486,15 @@
   <div class="header-inner">
     <div style="display:flex;align-items:center;gap:16px">
       <button class="menu-toggle" onclick="toggleSidebar()" aria-label="Menu">&#9776;</button>
-      <a href="#" class="header-brand">
+      <a href="index.html" class="header-brand">
         <span class="header-brand-icon">&#x1F52C;</span> sciClaw
       </a>
     </div>
     <nav class="header-nav">
-      <a href="#" class="active">Documentation</a>
+      <a href="docs.html" class="active">Docs</a>
+      <a href="philosophy.html">Philosophy</a>
       <a href="biography.html">Creator</a>
-      <a href="https://github.com/drpedapati/sciclaw" target="_blank" rel="noopener">Source code</a>
-      <a href="https://github.com/drpedapati/sciclaw/issues" target="_blank" rel="noopener" class="hide-mobile">Help</a>
+      <a href="https://github.com/drpedapati/sciclaw" target="_blank" rel="noopener">GitHub</a>
       <button class="theme-toggle" id="themeToggle" onclick="toggleTheme()" aria-label="Toggle dark mode" title="Toggle dark mode">&#9790;</button>
     </nav>
   </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -82,7 +82,8 @@
           sciClaw
         </a>
         <nav class="nav-links">
-          <a class="util" href="docs.html">Documentation</a>
+          <a class="util" href="docs.html">Docs</a>
+          <a class="util" href="philosophy.html">Philosophy</a>
           <a class="util" href="biography.html">Creator</a>
           <a class="util" href="https://github.com/drpedapati/sciclaw" target="_blank" rel="noopener noreferrer">GitHub</a>
           <a class="btn btn-primary" href="section-install.html" style="padding:6px 12px;font-size:12px;">Install</a>

--- a/docs/philosophy.html
+++ b/docs/philosophy.html
@@ -170,8 +170,8 @@
         sciClaw
       </a>
       <nav class="nav-links">
-        <a class="util" href="index.html">Home</a>
-        <a class="util" href="docs.html">Documentation</a>
+        <a class="util" href="docs.html">Docs</a>
+        <a class="util active" href="philosophy.html">Philosophy</a>
         <a class="util" href="biography.html">Creator</a>
         <a class="util" href="https://github.com/drpedapati/sciclaw" target="_blank" rel="noopener noreferrer">GitHub</a>
       </nav>


### PR DESCRIPTION
## Summary
- All pages now have consistent nav: **Docs, Philosophy, Creator, GitHub**
- docs.html logo now links to index.html (landing page)
- Shortened 'Documentation' to 'Docs' for consistency  
- Removed 'Home' link from subpages (clicking logo serves this purpose)
- Added active class for current page highlighting

## Changes
| Page | Before | After |
|------|--------|-------|
| index.html | Documentation, Creator, GitHub | Docs, Philosophy, Creator, GitHub |
| docs.html | Logo -> #, Documentation, Creator, Source code, Help | Logo -> index.html, Docs, Philosophy, Creator, GitHub |
| biography.html | Home, Documentation, Philosophy, GitHub | Docs, Philosophy, Creator (active), GitHub |
| philosophy.html | Home, Documentation, Creator, GitHub | Docs, Philosophy (active), Creator, GitHub |

Generated with Claude Code