### PR TITLE
feat(tui): routing wizard, settings tab, and UX improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ auth.json
 
 # Manuscript files (private)
 manuscript/
+
+env.local

--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ sciclaw onboard
 ```bash
 sciclaw auth login --provider openai     # OAuth device code — works with your ChatGPT account
 sciclaw auth login --provider anthropic  # Token paste
+
+# Optional: import from 1Password item JSON (requires OP_SERVICE_ACCOUNT_TOKEN)
+export OP_SERVICE_ACCOUNT_TOKEN="ops_..."
+sciclaw auth import-op --provider openai --item "OpenAI Credentials"
+sciclaw auth import-op --provider anthropic --item "Anthropic Token" --vault "AI" --auth-method token
 ```
 
 **3. Connect a chat app** and start messaging:
@@ -447,7 +452,7 @@ Last refreshed:
 | `sciclaw gateway` | Start chat gateway |
 | `sciclaw service install\|start\|stop\|restart\|logs\|uninstall` | Manage background service |
 | `sciclaw channels setup <channel>` | Configure a chat channel |
-| `sciclaw auth login\|status` | Manage credentials |
+| `sciclaw auth login\|logout\|status\|import-op` | Manage credentials |
 | `sciclaw skills list\|install` | Manage skills |
 | `sciclaw cron list\|add` | Manage scheduled jobs |
 

--- a/cmd/picoclaw/tui/snapshot.go
+++ b/cmd/picoclaw/tui/snapshot.go
@@ -337,13 +337,13 @@ func (s *VMSnapshot) SuggestedStep() (message, detail string, tabIdx int) {
 		return "Log in to an AI provider", "You need credentials for OpenAI or Anthropic to use the agent.", tabLogin
 	}
 	if s.Discord.Status != "ready" && s.Telegram.Status != "ready" {
-		return "Set up a messaging app", "Connect Discord or Telegram so you can chat with your agent.", tabChannels
+		return "Set up a channel", "Connect Discord or Telegram so you can chat with your agent.", tabChannels
 	}
 	if !s.ServiceInstalled {
-		return "Install the gateway service", "The background service lets your agent run continuously.", tabAgent
+		return "Install the gateway service", "The background service lets your gateway run continuously.", tabAgent
 	}
 	if !s.ServiceRunning {
-		return "Start the gateway service", "Your agent is installed but not running yet.", tabAgent
+		return "Start the gateway service", "The gateway service is installed but not running yet.", tabAgent
 	}
-	return "You're all set!", "Your agent is running and ready. Check the logs for activity.", tabAgent
+	return "You're all set!", "Your gateway is running and ready. Check the logs for activity.", tabAgent
 }

--- a/cmd/picoclaw/tui/tab_home.go
+++ b/cmd/picoclaw/tui/tab_home.go
@@ -38,6 +38,9 @@ func (m HomeModel) View(snap *VMSnapshot, width int) string {
 	}
 
 	panelW := width - 4
+	if panelW > 100 {
+		panelW = 100
+	}
 	if panelW < 40 {
 		panelW = 40
 	}
@@ -75,10 +78,16 @@ func renderSystemInfoPanel(snap *VMSnapshot, w int) string {
 		backend = "launchd (user)"
 	}
 
+	wsPath := snap.WorkspacePath
+	if wsPath == "" {
+		wsPath = styleDim.Render("not set")
+	}
+
 	content := fmt.Sprintf(
-		"%s %s\n%s %s\n%s %s\n%s %s",
+		"%s %s\n%s %s\n%s %s\n%s %s\n%s %s",
 		styleLabel.Render("Mode:"), styleOK.Render("Local"),
 		styleLabel.Render("System:"), styleValue.Render(osStr),
+		styleLabel.Render("Workspace:"), wsPath,
 		styleLabel.Render("Service:"), styleValue.Render(backend),
 		styleLabel.Render("Agent:"), styleValue.Render(verStr),
 	)
@@ -116,12 +125,18 @@ func renderVMInfoPanel(snap *VMSnapshot, w int) string {
 		verStr = "-"
 	}
 
+	wsPath := snap.WorkspacePath
+	if wsPath == "" {
+		wsPath = styleDim.Render("not set")
+	}
+
 	content := fmt.Sprintf(
-		"%s %s    %s %s\n%s %s    %s %s\n%s %s",
+		"%s %s    %s %s\n%s %s    %s %s\n%s %s\n%s %s",
 		styleLabel.Render("Status:"), stateStyle.Render(snap.State),
 		styleLabel.Render("IP:"), styleValue.Render(ipStr),
 		styleLabel.Render("CPU Load:"), styleValue.Render(loadStr),
 		styleLabel.Render("Memory:"), styleValue.Render(memStr),
+		styleLabel.Render("Workspace:"), wsPath,
 		styleLabel.Render("Agent:"), styleValue.Render(verStr),
 	)
 
@@ -235,7 +250,7 @@ func channelCheckLabel(discord, telegram ChannelSnapshot) string {
 		parts = append(parts, t)
 	}
 	if len(parts) > 0 {
-		return fmt.Sprintf("Messaging app (%s)", strings.Join(parts, ", "))
+		return fmt.Sprintf("Channel (%s)", strings.Join(parts, ", "))
 	}
-	return "Messaging app (not configured)"
+	return "Channel (not configured)"
 }

--- a/cmd/picoclaw/tui/tab_routing.go
+++ b/cmd/picoclaw/tui/tab_routing.go
@@ -2,10 +2,12 @@ package tui
 
 import (
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -16,6 +18,22 @@ type routingMode int
 const (
 	routingNormal routingMode = iota
 	routingConfirmRemove
+	routingAddWizard
+	routingEditUsers
+	routingBrowseFolder
+	routingPickRoom
+	routingPairTelegram
+)
+
+// Wizard steps for adding a mapping.
+const (
+	addStepChannel       = 0
+	addStepChatID        = 1 // Discord: auto-picker; Telegram: choice screen
+	addStepWorkspace     = 2
+	addStepAllow         = 3
+	addStepLabel         = 4
+	addStepConfirm       = 5
+	addStepChatIDManual  = 6 // manual text input fallback (both channels)
 )
 
 // Messages for async routing operations.
@@ -23,6 +41,27 @@ type routingStatusMsg struct{ output string }
 type routingListMsg struct{ output string }
 type routingValidateMsg struct{ output string }
 type routingReloadMsg struct{ output string }
+type routingDirListMsg struct {
+	path string
+	dirs []string
+	err  string
+}
+type routingDiscordRoomsMsg struct {
+	rooms []discordRoom
+	err   string
+}
+type routingTelegramPairMsg struct {
+	chatID   string
+	chatType string
+	username string
+	err      string
+}
+
+type discordRoom struct {
+	ChannelID   string
+	GuildName   string
+	ChannelName string
+}
 
 type routingStatusInfo struct {
 	Enabled          bool
@@ -58,6 +97,35 @@ type RoutingModel struct {
 	// Remove confirmation
 	removeMapping routingRow
 
+	// Add-mapping wizard state
+	wizardStep    int
+	wizardChannel string
+	wizardChatID  string
+	wizardPath    string
+	wizardAllow   string
+	wizardLabel   string
+	wizardInput   textinput.Model
+
+	// Edit-users state
+	editUsersInput textinput.Model
+
+	// Folder browser state
+	browserPath    string
+	browserEntries []string
+	browserCursor  int
+	browserLoading bool
+	browserErr     string
+
+	// Discord room picker state
+	discordRooms []discordRoom
+	roomCursor   int
+	roomsLoading bool
+	roomsErr     string
+
+	// Telegram pairing state
+	pairLoading bool
+	pairErr     string
+
 	// Inline feedback
 	flashMsg   string
 	flashUntil time.Time
@@ -69,10 +137,20 @@ func NewRoutingModel(exec Executor) RoutingModel {
 	detailVP := viewport.New(60, 6)
 	detailVP.KeyMap = viewport.KeyMap{}
 
+	wi := textinput.New()
+	wi.CharLimit = 200
+	wi.Width = 50
+
+	ei := textinput.New()
+	ei.CharLimit = 200
+	ei.Width = 50
+
 	return RoutingModel{
-		exec:     exec,
-		listVP:   listVP,
-		detailVP: detailVP,
+		exec:           exec,
+		listVP:         listVP,
+		detailVP:       detailVP,
+		wizardInput:    wi,
+		editUsersInput: ei,
 	}
 }
 
@@ -117,10 +195,28 @@ func (m *RoutingModel) HandleReload(msg routingReloadMsg) {
 	m.flashUntil = time.Now().Add(5 * time.Second)
 }
 
+func (m *RoutingModel) HandleDirList(msg routingDirListMsg) {
+	m.browserLoading = false
+	if msg.path != m.browserPath {
+		return // stale response
+	}
+	if msg.err != "" {
+		m.browserErr = msg.err
+		m.browserEntries = nil
+	} else {
+		m.browserErr = ""
+		m.browserEntries = msg.dirs
+		m.browserCursor = 0
+	}
+}
+
 func (m *RoutingModel) HandleResize(width, height int) {
 	m.width = width
 	m.height = height
 	w := width - 8
+	if w > 96 {
+		w = 96
+	}
 	if w < 40 {
 		w = 40
 	}
@@ -156,22 +252,22 @@ func (m *RoutingModel) rebuildListContent() {
 			indicator = styleBold.Foreground(colorAccent).Render("▸ ")
 		}
 
-		chatID := r.ChatID
-		if len(chatID) > 14 {
-			chatID = chatID[:12] + "…"
-		}
-
 		label := r.Label
 		if label == "" || label == "-" {
-			label = styleDim.Render("—")
+			// Fallback: use last segment of workspace path.
+			label = filepath.Base(r.Workspace)
+			if label == "." || label == "/" || label == "" {
+				label = "untitled"
+			}
 		}
 
-		channel := r.Channel
+		shortPath := truncatePathComponents(r.Workspace, 2)
+
 		if i == m.selectedRow {
-			channel = styleBold.Render(channel)
+			label = styleBold.Render(label)
 		}
 
-		line := fmt.Sprintf("  %s%-10s %-14s  %s", indicator, channel, chatID, label)
+		line := fmt.Sprintf("  %s%-16s %s", indicator, label, styleDim.Render(r.Channel+" \u2192 "+shortPath))
 		if i == m.selectedRow {
 			line = lipgloss.NewStyle().
 				Background(lipgloss.Color("#2A2A4A")).
@@ -183,6 +279,27 @@ func (m *RoutingModel) rebuildListContent() {
 	m.listVP.SetContent(strings.Join(lines, "\n"))
 }
 
+// truncatePathComponents returns the last n path components, prefixed with ".../" if truncated.
+func truncatePathComponents(p string, n int) string {
+	if p == "" {
+		return p
+	}
+	// Replace home dir prefix with ~.
+	cleaned := filepath.Clean(p)
+	parts := strings.Split(cleaned, string(filepath.Separator))
+	// Remove empty leading element from absolute paths.
+	var nonEmpty []string
+	for _, s := range parts {
+		if s != "" {
+			nonEmpty = append(nonEmpty, s)
+		}
+	}
+	if len(nonEmpty) <= n {
+		return p
+	}
+	return "\u2026/" + strings.Join(nonEmpty[len(nonEmpty)-n:], "/")
+}
+
 func (m *RoutingModel) rebuildDetailContent() {
 	if len(m.mappings) == 0 || m.selectedRow >= len(m.mappings) {
 		m.detailVP.SetContent(styleDim.Render("  Select a mapping to view details."))
@@ -190,16 +307,34 @@ func (m *RoutingModel) rebuildDetailContent() {
 	}
 
 	r := m.mappings[m.selectedRow]
+	maxValW := m.detailVP.Width - 18
+	if maxValW < 20 {
+		maxValW = 20
+	}
+
+	detailLabel := lipgloss.NewStyle().Foreground(colorMuted).Width(16)
+
 	var lines []string
-	lines = append(lines, fmt.Sprintf("  %s  %s", styleLabel.Render("Channel:"), styleValue.Render(r.Channel)))
-	lines = append(lines, fmt.Sprintf("  %s  %s", styleLabel.Render("Chat ID:"), styleValue.Render(r.ChatID)))
+	lines = append(lines, fmt.Sprintf("  %s  %s", detailLabel.Render("Channel:"), styleValue.Render(r.Channel)))
+	lines = append(lines, fmt.Sprintf("  %s  %s", detailLabel.Render("Chat room:"), styleValue.Render(r.ChatID)))
 	if r.Label != "" && r.Label != "-" {
-		lines = append(lines, fmt.Sprintf("  %s  %s", styleLabel.Render("Label:"), styleValue.Render(r.Label)))
+		lines = append(lines, fmt.Sprintf("  %s  %s", detailLabel.Render("Label:"), styleValue.Render(r.Label)))
 	}
-	lines = append(lines, fmt.Sprintf("  %s  %s", styleLabel.Render("Workspace:"), r.Workspace))
+	ws := r.Workspace
+	if len(ws) > maxValW {
+		ws = "\u2026" + ws[len(ws)-maxValW+1:]
+	}
+	lines = append(lines, fmt.Sprintf("  %s  %s", detailLabel.Render("Folder:"), ws))
 	if r.AllowedSenders != "" {
-		lines = append(lines, fmt.Sprintf("  %s  %s", styleLabel.Render("Senders:"), r.AllowedSenders))
+		senders := r.AllowedSenders
+		if len(senders) > maxValW {
+			senders = senders[:maxValW-1] + "\u2026"
+		}
+		lines = append(lines, fmt.Sprintf("  %s  %s", detailLabel.Render("Allowed users:"), senders))
 	}
+	lines = append(lines, "")
+	modifyCmd := fmt.Sprintf("sciclaw routing set-users --channel %s --chat-id %s --allow <ids>", r.Channel, r.ChatID)
+	lines = append(lines, "  "+styleDim.Render("Modify: ")+styleValue.Render(modifyCmd))
 	m.detailVP.SetContent(strings.Join(lines, "\n"))
 	m.detailVP.GotoTop()
 }
@@ -299,21 +434,37 @@ func parseRoutingList(output string) []routingRow {
 // --- Update ---
 
 func (m RoutingModel) Update(msg tea.KeyMsg, snap *VMSnapshot) (RoutingModel, tea.Cmd) {
-	key := msg.String()
-
-	if m.mode == routingConfirmRemove {
-		switch key {
-		case "y", "Y":
-			m.mode = routingNormal
-			return m, routingRemoveCmd(m.exec, m.removeMapping.Channel, m.removeMapping.ChatID)
-		case "n", "N", "esc":
-			m.mode = routingNormal
-		}
-		return m, nil
+	switch m.mode {
+	case routingConfirmRemove:
+		return m.updateConfirmRemove(msg)
+	case routingAddWizard:
+		return m.updateAddWizard(msg, snap)
+	case routingEditUsers:
+		return m.updateEditUsers(msg)
+	case routingBrowseFolder:
+		return m.updateBrowseFolder(msg, snap)
+	case routingPickRoom:
+		return m.updatePickRoom(msg, snap)
+	case routingPairTelegram:
+		return m.updatePairTelegram(msg)
+	default:
+		return m.updateNormal(msg, snap)
 	}
+}
 
-	// Normal mode.
-	switch key {
+func (m RoutingModel) updateConfirmRemove(msg tea.KeyMsg) (RoutingModel, tea.Cmd) {
+	switch msg.String() {
+	case "y", "Y":
+		m.mode = routingNormal
+		return m, routingRemoveCmd(m.exec, m.removeMapping.Channel, m.removeMapping.ChatID)
+	case "n", "N", "esc":
+		m.mode = routingNormal
+	}
+	return m, nil
+}
+
+func (m RoutingModel) updateNormal(msg tea.KeyMsg, snap *VMSnapshot) (RoutingModel, tea.Cmd) {
+	switch msg.String() {
 	case "up", "k":
 		if m.selectedRow > 0 {
 			m.selectedRow--
@@ -342,6 +493,383 @@ func (m RoutingModel) Update(msg tea.KeyMsg, snap *VMSnapshot) (RoutingModel, te
 	case "l":
 		m.loaded = false
 		return m, tea.Batch(fetchRoutingStatus(m.exec), fetchRoutingListCmd(m.exec))
+	case "a":
+		return m.startAddWizard(snap)
+	case "u":
+		return m.startEditUsers()
+	}
+	return m, nil
+}
+
+// --- Add Wizard ---
+
+func (m RoutingModel) startAddWizard(snap *VMSnapshot) (RoutingModel, tea.Cmd) {
+	m.mode = routingAddWizard
+	m.wizardStep = addStepChannel
+	m.wizardChannel = "discord"
+	m.wizardChatID = ""
+	m.wizardPath = ""
+	m.wizardAllow = ""
+	m.wizardLabel = ""
+	m.wizardInput.SetValue("")
+	m.wizardInput.Blur()
+	return m, nil
+}
+
+func (m RoutingModel) updateAddWizard(msg tea.KeyMsg, snap *VMSnapshot) (RoutingModel, tea.Cmd) {
+	key := msg.String()
+
+	if key == "esc" {
+		m.mode = routingNormal
+		m.wizardInput.Blur()
+		return m, nil
+	}
+
+	switch m.wizardStep {
+	case addStepChannel:
+		switch key {
+		case "left", "right", " ":
+			if m.wizardChannel == "discord" {
+				m.wizardChannel = "telegram"
+			} else {
+				m.wizardChannel = "discord"
+			}
+		case "enter":
+			m.wizardStep = addStepChatID
+			if m.wizardChannel == "discord" {
+				// Auto-transition to Discord room picker
+				return m.startDiscordPicker()
+			}
+			// Telegram: show choice screen (p/m)
+		}
+		return m, nil
+
+	case addStepChatID:
+		// Telegram choice screen: [p] pair or [m] manual
+		switch key {
+		case "p":
+			return m.startTelegramPair()
+		case "m":
+			m.wizardStep = addStepChatIDManual
+			m.wizardInput.SetValue("")
+			m.wizardInput.Placeholder = "e.g. -1001234567890"
+			m.wizardInput.Focus()
+		}
+		return m, nil
+
+	case addStepChatIDManual:
+		if key == "enter" {
+			val := strings.TrimSpace(m.wizardInput.Value())
+			if val == "" {
+				return m, nil
+			}
+			m.wizardChatID = val
+			m.wizardStep = addStepWorkspace
+			m.wizardInput.SetValue("")
+			m.wizardInput.Placeholder = "/absolute/path/to/workspace"
+			if snap != nil && snap.WorkspacePath != "" {
+				m.wizardInput.SetValue(snap.WorkspacePath)
+			}
+			return m, nil
+		}
+		var cmd tea.Cmd
+		m.wizardInput, cmd = m.wizardInput.Update(msg)
+		return m, cmd
+
+	case addStepWorkspace:
+		switch key {
+		case "enter":
+			val := strings.TrimSpace(m.wizardInput.Value())
+			if val == "" {
+				return m, nil
+			}
+			m.wizardPath = val
+			m.wizardStep = addStepAllow
+			m.wizardInput.SetValue("")
+			m.wizardInput.Placeholder = "sender_id1,sender_id2"
+			return m, nil
+		case "ctrl+b":
+			return m, m.startBrowse(snap)
+		}
+		var cmd tea.Cmd
+		m.wizardInput, cmd = m.wizardInput.Update(msg)
+		return m, cmd
+
+	case addStepAllow:
+		if key == "enter" {
+			val := strings.TrimSpace(m.wizardInput.Value())
+			if val == "" {
+				return m, nil
+			}
+			m.wizardAllow = val
+			m.wizardStep = addStepLabel
+			m.wizardInput.SetValue("")
+			m.wizardInput.Placeholder = "(optional label)"
+			return m, nil
+		}
+		var cmd tea.Cmd
+		m.wizardInput, cmd = m.wizardInput.Update(msg)
+		return m, cmd
+
+	case addStepLabel:
+		if key == "enter" {
+			m.wizardLabel = strings.TrimSpace(m.wizardInput.Value())
+			m.wizardStep = addStepConfirm
+			m.wizardInput.Blur()
+			return m, nil
+		}
+		var cmd tea.Cmd
+		m.wizardInput, cmd = m.wizardInput.Update(msg)
+		return m, cmd
+
+	case addStepConfirm:
+		if key == "enter" {
+			m.mode = routingNormal
+			return m, routingAddMappingCmd(m.exec, m.wizardChannel, m.wizardChatID,
+				m.wizardPath, m.wizardAllow, m.wizardLabel)
+		}
+		return m, nil
+	}
+
+	return m, nil
+}
+
+// --- Folder Browser ---
+
+func (m *RoutingModel) startBrowse(snap *VMSnapshot) tea.Cmd {
+	m.mode = routingBrowseFolder
+	startPath := strings.TrimSpace(m.wizardInput.Value())
+	if startPath == "" || !strings.HasPrefix(startPath, "/") {
+		if snap != nil && snap.WorkspacePath != "" {
+			startPath = snap.WorkspacePath
+		} else {
+			startPath = m.exec.HomePath()
+		}
+	}
+	m.browserPath = startPath
+	m.browserCursor = 0
+	m.browserLoading = true
+	m.browserErr = ""
+	m.browserEntries = nil
+	m.wizardInput.Blur()
+	return fetchDirListCmd(m.exec, startPath)
+}
+
+func (m RoutingModel) updateBrowseFolder(msg tea.KeyMsg, snap *VMSnapshot) (RoutingModel, tea.Cmd) {
+	key := msg.String()
+
+	switch key {
+	case "esc":
+		m.mode = routingAddWizard
+		m.wizardStep = addStepWorkspace
+		m.wizardInput.SetValue(m.browserPath)
+		m.wizardInput.Focus()
+		return m, nil
+
+	case "up", "k":
+		if m.browserCursor > 0 {
+			m.browserCursor--
+		}
+		return m, nil
+
+	case "down", "j":
+		maxIdx := len(m.browserEntries) + 1 // ".." + entries + "[Select]"
+		if m.browserCursor < maxIdx {
+			m.browserCursor++
+		}
+		return m, nil
+
+	case "enter":
+		selectIdx := len(m.browserEntries) + 1
+		if m.browserCursor == 0 {
+			// Go up to parent
+			parent := filepath.Dir(m.browserPath)
+			if parent == m.browserPath {
+				return m, nil
+			}
+			m.browserPath = parent
+			m.browserCursor = 0
+			m.browserLoading = true
+			return m, fetchDirListCmd(m.exec, parent)
+		} else if m.browserCursor == selectIdx {
+			// Select current folder
+			m.mode = routingAddWizard
+			m.wizardStep = addStepWorkspace
+			m.wizardInput.SetValue(m.browserPath)
+			m.wizardInput.Focus()
+			return m, nil
+		} else {
+			// Descend into directory
+			dirName := m.browserEntries[m.browserCursor-1]
+			newPath := filepath.Join(m.browserPath, dirName)
+			m.browserPath = newPath
+			m.browserCursor = 0
+			m.browserLoading = true
+			return m, fetchDirListCmd(m.exec, newPath)
+		}
+
+	case " ":
+		// Space selects current folder
+		m.mode = routingAddWizard
+		m.wizardStep = addStepWorkspace
+		m.wizardInput.SetValue(m.browserPath)
+		m.wizardInput.Focus()
+		return m, nil
+	}
+
+	return m, nil
+}
+
+// --- Edit Users ---
+
+func (m RoutingModel) startEditUsers() (RoutingModel, tea.Cmd) {
+	if m.selectedRow >= len(m.mappings) {
+		return m, nil
+	}
+	m.mode = routingEditUsers
+	row := m.mappings[m.selectedRow]
+	m.editUsersInput.SetValue(row.AllowedSenders)
+	m.editUsersInput.Placeholder = "sender_id1,sender_id2"
+	m.editUsersInput.Focus()
+	return m, nil
+}
+
+func (m RoutingModel) updateEditUsers(msg tea.KeyMsg) (RoutingModel, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.mode = routingNormal
+		m.editUsersInput.Blur()
+		return m, nil
+	case "enter":
+		val := strings.TrimSpace(m.editUsersInput.Value())
+		if val == "" {
+			m.mode = routingNormal
+			m.editUsersInput.Blur()
+			return m, nil
+		}
+		row := m.mappings[m.selectedRow]
+		m.mode = routingNormal
+		m.editUsersInput.Blur()
+		return m, routingSetUsersCmd(m.exec, row.Channel, row.ChatID, val)
+	}
+	var cmd tea.Cmd
+	m.editUsersInput, cmd = m.editUsersInput.Update(msg)
+	return m, cmd
+}
+
+// --- Discord Room Picker ---
+
+func (m RoutingModel) startDiscordPicker() (RoutingModel, tea.Cmd) {
+	m.mode = routingPickRoom
+	m.discordRooms = nil
+	m.roomCursor = 0
+	m.roomsLoading = true
+	m.roomsErr = ""
+	return m, fetchDiscordRoomsCmd(m.exec)
+}
+
+func (m *RoutingModel) HandleDiscordRooms(msg routingDiscordRoomsMsg) {
+	m.roomsLoading = false
+	if msg.err != "" {
+		m.roomsErr = msg.err
+		m.discordRooms = nil
+	} else {
+		m.roomsErr = ""
+		m.discordRooms = msg.rooms
+		m.roomCursor = 0
+	}
+}
+
+func (m RoutingModel) updatePickRoom(msg tea.KeyMsg, snap *VMSnapshot) (RoutingModel, tea.Cmd) {
+	key := msg.String()
+
+	switch key {
+	case "esc":
+		m.mode = routingNormal
+		m.wizardInput.Blur()
+		return m, nil
+
+	case "up", "k":
+		if m.roomCursor > 0 {
+			m.roomCursor--
+		}
+		return m, nil
+
+	case "down", "j":
+		if m.roomCursor < len(m.discordRooms)-1 {
+			m.roomCursor++
+		}
+		return m, nil
+
+	case "enter":
+		if len(m.discordRooms) > 0 && m.roomCursor < len(m.discordRooms) {
+			room := m.discordRooms[m.roomCursor]
+			m.wizardChatID = room.ChannelID
+			if m.wizardLabel == "" {
+				m.wizardLabel = room.GuildName + "/" + room.ChannelName
+			}
+			m.mode = routingAddWizard
+			m.wizardStep = addStepWorkspace
+			m.wizardInput.SetValue("")
+			m.wizardInput.Placeholder = "/absolute/path/to/workspace"
+			if snap != nil && snap.WorkspacePath != "" {
+				m.wizardInput.SetValue(snap.WorkspacePath)
+			}
+			m.wizardInput.Focus()
+		}
+		return m, nil
+
+	case "m":
+		// Switch to manual entry
+		m.mode = routingAddWizard
+		m.wizardStep = addStepChatIDManual
+		m.wizardInput.SetValue("")
+		m.wizardInput.Placeholder = "e.g. 1234567890123"
+		m.wizardInput.Focus()
+		return m, nil
+	}
+
+	return m, nil
+}
+
+// --- Telegram Pairing ---
+
+func (m RoutingModel) startTelegramPair() (RoutingModel, tea.Cmd) {
+	m.mode = routingPairTelegram
+	m.pairLoading = true
+	m.pairErr = ""
+	return m, startTelegramPairCmd(m.exec)
+}
+
+func (m *RoutingModel) HandleTelegramPair(msg routingTelegramPairMsg) {
+	m.pairLoading = false
+	if msg.err != "" {
+		m.pairErr = msg.err
+		// Return to wizard choice screen
+		m.mode = routingAddWizard
+		m.wizardStep = addStepChatID
+	} else {
+		m.pairErr = ""
+		m.wizardChatID = msg.chatID
+		if msg.username != "" && m.wizardLabel == "" {
+			m.wizardLabel = msg.username
+		}
+		// Advance to workspace step
+		m.mode = routingAddWizard
+		m.wizardStep = addStepWorkspace
+		m.wizardInput.SetValue("")
+		m.wizardInput.Placeholder = "/absolute/path/to/workspace"
+		m.wizardInput.Focus()
+		m.flashMsg = styleOK.Render("Detected chat: " + msg.chatID)
+		m.flashUntil = time.Now().Add(5 * time.Second)
+	}
+}
+
+func (m RoutingModel) updatePairTelegram(msg tea.KeyMsg) (RoutingModel, tea.Cmd) {
+	if msg.String() == "esc" {
+		m.mode = routingAddWizard
+		m.wizardStep = addStepChatID
+		return m, nil
 	}
 	return m, nil
 }
@@ -350,6 +878,9 @@ func (m RoutingModel) Update(msg tea.KeyMsg, snap *VMSnapshot) (RoutingModel, te
 
 func (m RoutingModel) View(snap *VMSnapshot, width int) string {
 	panelW := width - 4
+	if panelW > 100 {
+		panelW = 100
+	}
 	if panelW < 40 {
 		panelW = 40
 	}
@@ -359,6 +890,51 @@ func (m RoutingModel) View(snap *VMSnapshot, width int) string {
 	}
 
 	var b strings.Builder
+
+	// Empty state: show onboarding guidance instead of empty panels.
+	if len(m.mappings) == 0 {
+		var guide []string
+		guide = append(guide, "")
+		guide = append(guide, styleDim.Render("  Route messages from different chat rooms to separate workspace folders."))
+		guide = append(guide, styleDim.Render("  Each room gets its own isolated workspace so team members can work on"))
+		guide = append(guide, styleDim.Render("  different projects without interference."))
+		guide = append(guide, "")
+		guide = append(guide, fmt.Sprintf("  %s Add a mapping   %s Enable/Disable routing   %s Refresh",
+			styleKey.Render("[a]"),
+			styleKey.Render("[t]"),
+			styleKey.Render("[l]"),
+		))
+
+		content := strings.Join(guide, "\n")
+		panel := stylePanel.Width(panelW).Render(content)
+		title := stylePanelTitle.Render("Channel Routing")
+		b.WriteString(placePanelTitle(panel, title))
+
+		// Flash message.
+		if !m.flashUntil.IsZero() && time.Now().Before(m.flashUntil) {
+			b.WriteString("  " + m.flashMsg + "\n")
+		}
+
+		// Wizard overlay (can be triggered from empty state).
+		if m.mode == routingAddWizard {
+			b.WriteString("\n")
+			b.WriteString(m.renderAddWizardOverlay())
+		}
+		if m.mode == routingBrowseFolder {
+			b.WriteString("\n")
+			b.WriteString(m.renderFolderBrowser())
+		}
+		if m.mode == routingPickRoom {
+			b.WriteString("\n")
+			b.WriteString(m.renderDiscordPicker())
+		}
+		if m.mode == routingPairTelegram {
+			b.WriteString("\n")
+			b.WriteString(m.renderTelegramPairing())
+		}
+
+		return b.String()
+	}
 
 	// Status panel.
 	b.WriteString(m.renderStatusPanel(panelW))
@@ -376,7 +952,9 @@ func (m RoutingModel) View(snap *VMSnapshot, width int) string {
 	b.WriteString(placePanelTitle(detailPanel, detailTitle))
 
 	// Keybindings.
-	b.WriteString(fmt.Sprintf("  %s Toggle   %s Remove   %s Validate   %s Reload   %s Refresh\n",
+	b.WriteString(fmt.Sprintf("  %s Add   %s Edit Users   %s Toggle   %s Remove   %s Check   %s Apply   %s Refresh\n",
+		styleKey.Render("[a]"),
+		styleKey.Render("[u]"),
 		styleKey.Render("[t]"),
 		styleKey.Render("[d]"),
 		styleKey.Render("[v]"),
@@ -399,6 +977,36 @@ func (m RoutingModel) View(snap *VMSnapshot, width int) string {
 		))
 	}
 
+	// Overlay: add wizard.
+	if m.mode == routingAddWizard {
+		b.WriteString("\n")
+		b.WriteString(m.renderAddWizardOverlay())
+	}
+
+	// Overlay: edit users.
+	if m.mode == routingEditUsers {
+		b.WriteString("\n")
+		b.WriteString(m.renderEditUsersOverlay())
+	}
+
+	// Overlay: folder browser.
+	if m.mode == routingBrowseFolder {
+		b.WriteString("\n")
+		b.WriteString(m.renderFolderBrowser())
+	}
+
+	// Overlay: Discord room picker.
+	if m.mode == routingPickRoom {
+		b.WriteString("\n")
+		b.WriteString(m.renderDiscordPicker())
+	}
+
+	// Overlay: Telegram pairing.
+	if m.mode == routingPairTelegram {
+		b.WriteString("\n")
+		b.WriteString(m.renderTelegramPairing())
+	}
+
 	return b.String()
 }
 
@@ -410,24 +1018,20 @@ func (m RoutingModel) renderStatusPanel(panelW int) string {
 		enabledText = styleErr.Render("No")
 	}
 
-	invalidText := fmt.Sprintf("%d", m.status.InvalidCount)
-	if m.status.InvalidCount > 0 {
-		invalidText = styleErr.Render(invalidText)
+	unmappedDisplay := m.status.UnmappedBehavior
+	switch unmappedDisplay {
+	case "block":
+		unmappedDisplay = "blocked"
+	case "default":
+		unmappedDisplay = "use default workspace"
 	}
 
-	validationIcon := styleOK.Render("✓")
-	validationText := m.status.ValidationMsg
-	if !m.status.ValidationOK {
-		validationIcon = styleErr.Render("✗")
-		validationText = styleErr.Render(validationText)
-	}
+	statusLabel := lipgloss.NewStyle().Foreground(colorMuted).Width(16)
 
 	var lines []string
-	lines = append(lines, fmt.Sprintf("  Enabled: %s %s    Mappings: %s",
-		enabledIcon, enabledText, styleBold.Render(fmt.Sprintf("%d", m.status.MappingCount))))
-	lines = append(lines, fmt.Sprintf("  Unmapped: %s   Invalid: %s",
-		styleBold.Render(m.status.UnmappedBehavior), invalidText))
-	lines = append(lines, fmt.Sprintf("  Validation: %s %s", validationIcon, validationText))
+	lines = append(lines, fmt.Sprintf("  %s  %s %s", statusLabel.Render("Enabled:"), enabledIcon, enabledText))
+	lines = append(lines, fmt.Sprintf("  %s  %s", statusLabel.Render("Mappings:"), styleBold.Render(fmt.Sprintf("%d", m.status.MappingCount))))
+	lines = append(lines, fmt.Sprintf("  %s  %s", statusLabel.Render("Unknown rooms:"), styleBold.Render(unmappedDisplay)))
 
 	content := strings.Join(lines, "\n")
 	panel := stylePanel.Width(panelW).Render(content)
@@ -488,4 +1092,329 @@ func routingReloadCmd(exec Executor) tea.Cmd {
 		out, _ := exec.ExecShell(10*time.Second, cmd)
 		return routingReloadMsg{output: out}
 	}
+}
+
+func routingAddMappingCmd(exec Executor, channel, chatID, workspace, allowCSV, label string) tea.Cmd {
+	return func() tea.Msg {
+		cmd := fmt.Sprintf("HOME=%s sciclaw routing add --channel %s --chat-id %s --workspace %s --allow %s",
+			exec.HomePath(),
+			shellEscape(channel),
+			shellEscape(chatID),
+			shellEscape(workspace),
+			shellEscape(allowCSV),
+		)
+		if strings.TrimSpace(label) != "" {
+			cmd += " --label " + shellEscape(label)
+		}
+		cmd += " 2>&1"
+		out, _ := exec.ExecShell(10*time.Second, cmd)
+		return actionDoneMsg{output: strings.TrimSpace(out)}
+	}
+}
+
+func routingSetUsersCmd(exec Executor, channel, chatID, allowCSV string) tea.Cmd {
+	return func() tea.Msg {
+		cmd := fmt.Sprintf("HOME=%s sciclaw routing set-users --channel %s --chat-id %s --allow %s 2>&1",
+			exec.HomePath(),
+			shellEscape(channel),
+			shellEscape(chatID),
+			shellEscape(allowCSV),
+		)
+		out, _ := exec.ExecShell(10*time.Second, cmd)
+		return actionDoneMsg{output: strings.TrimSpace(out)}
+	}
+}
+
+func fetchDirListCmd(exec Executor, dirPath string) tea.Cmd {
+	return func() tea.Msg {
+		cmd := fmt.Sprintf("ls -1pF %s 2>/dev/null", shellEscape(dirPath))
+		out, err := exec.ExecShell(5*time.Second, cmd)
+		if err != nil {
+			return routingDirListMsg{path: dirPath, err: "Cannot read directory"}
+		}
+		var dirs []string
+		for _, line := range strings.Split(out, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			if strings.HasSuffix(line, "/") {
+				dirs = append(dirs, strings.TrimSuffix(line, "/"))
+			}
+		}
+		return routingDirListMsg{path: dirPath, dirs: dirs}
+	}
+}
+
+func fetchDiscordRoomsCmd(exec Executor) tea.Cmd {
+	return func() tea.Msg {
+		cmd := "HOME=" + exec.HomePath() + " sciclaw channels list-rooms --channel discord 2>&1"
+		out, err := exec.ExecShell(15*time.Second, cmd)
+		if err != nil || strings.TrimSpace(out) == "" {
+			errMsg := "Failed to list Discord channels"
+			if out != "" {
+				errMsg = strings.TrimSpace(out)
+			}
+			return routingDiscordRoomsMsg{err: errMsg}
+		}
+		var rooms []discordRoom
+		for _, line := range strings.Split(out, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			parts := strings.SplitN(line, "|", 3)
+			if len(parts) != 3 {
+				continue
+			}
+			rooms = append(rooms, discordRoom{
+				ChannelID:   parts[0],
+				GuildName:   parts[1],
+				ChannelName: parts[2],
+			})
+		}
+		if len(rooms) == 0 {
+			return routingDiscordRoomsMsg{err: "No text channels found"}
+		}
+		return routingDiscordRoomsMsg{rooms: rooms}
+	}
+}
+
+func startTelegramPairCmd(exec Executor) tea.Cmd {
+	return func() tea.Msg {
+		cmd := "HOME=" + exec.HomePath() + " sciclaw channels pair-telegram --timeout 15 2>&1"
+		out, err := exec.ExecShell(20*time.Second, cmd)
+		if err != nil || strings.TrimSpace(out) == "" {
+			errMsg := "Pairing timed out — no message received"
+			if out != "" {
+				errMsg = strings.TrimSpace(out)
+			}
+			return routingTelegramPairMsg{err: errMsg}
+		}
+		parts := strings.SplitN(strings.TrimSpace(out), "|", 3)
+		if len(parts) < 2 {
+			return routingTelegramPairMsg{err: "Unexpected response: " + out}
+		}
+		username := ""
+		if len(parts) >= 3 {
+			username = parts[2]
+		}
+		return routingTelegramPairMsg{
+			chatID:   parts[0],
+			chatType: parts[1],
+			username: username,
+		}
+	}
+}
+
+// --- Render overlays ---
+
+func (m RoutingModel) renderAddWizardOverlay() string {
+	var lines []string
+	displayStep := m.wizardStep + 1
+	if m.wizardStep == addStepChatIDManual {
+		displayStep = addStepChatID + 1 // show as step 2
+	}
+	lines = append(lines, styleBold.Render(fmt.Sprintf("  Add Routing Mapping (step %d/6)", displayStep)))
+
+	switch m.wizardStep {
+	case addStepChannel:
+		disco := styleDim.Render("  discord  ")
+		tele := styleDim.Render("  telegram  ")
+		if m.wizardChannel == "discord" {
+			disco = styleBold.Foreground(colorAccent).Render("[ discord ]")
+		} else {
+			tele = styleBold.Foreground(colorAccent).Render("[ telegram ]")
+		}
+		lines = append(lines, "  Channel: "+disco+"  "+tele)
+		lines = append(lines, styleHint.Render("    Left/Right to switch, Enter to continue"))
+
+	case addStepChatID:
+		// Telegram choice screen
+		lines = append(lines, "  How to identify the chat room:")
+		lines = append(lines, "")
+		lines = append(lines, fmt.Sprintf("    %s  Pair — send a message from the chat to detect it", styleKey.Render("[p]")))
+		lines = append(lines, fmt.Sprintf("    %s  Enter the chat ID manually", styleKey.Render("[m]")))
+		if m.pairErr != "" {
+			lines = append(lines, "")
+			lines = append(lines, "  "+styleErr.Render(m.pairErr))
+		}
+
+	case addStepChatIDManual:
+		lines = append(lines, fmt.Sprintf("  Chat room ID: %s", m.wizardInput.View()))
+		lines = append(lines, styleHint.Render("    The numeric chat/channel ID from "+m.wizardChannel))
+
+	case addStepWorkspace:
+		lines = append(lines, fmt.Sprintf("  Workspace path: %s", m.wizardInput.View()))
+		lines = append(lines, styleHint.Render("    Absolute path to the project folder"))
+		lines = append(lines, fmt.Sprintf("    %s to browse folders", styleKey.Render("Ctrl+B")))
+
+	case addStepAllow:
+		lines = append(lines, fmt.Sprintf("  Allowed senders: %s", m.wizardInput.View()))
+		lines = append(lines, styleHint.Render("    Comma-separated user IDs (e.g. 123456,789012)"))
+
+	case addStepLabel:
+		lines = append(lines, fmt.Sprintf("  Label (optional): %s", m.wizardInput.View()))
+		lines = append(lines, styleHint.Render("    A friendly name for this mapping. Press Enter to skip."))
+
+	case addStepConfirm:
+		lines = append(lines, "")
+		lines = append(lines, fmt.Sprintf("  %s", styleDim.Render("Review:")))
+		lines = append(lines, fmt.Sprintf("    Channel:  %s", styleValue.Render(m.wizardChannel)))
+		lines = append(lines, fmt.Sprintf("    Chat ID:  %s", styleValue.Render(m.wizardChatID)))
+		lines = append(lines, fmt.Sprintf("    Folder:   %s", styleValue.Render(m.wizardPath)))
+		lines = append(lines, fmt.Sprintf("    Allow:    %s", styleValue.Render(m.wizardAllow)))
+		if m.wizardLabel != "" {
+			lines = append(lines, fmt.Sprintf("    Label:    %s", styleValue.Render(m.wizardLabel)))
+		}
+		lines = append(lines, "")
+		lines = append(lines, fmt.Sprintf("  Press %s to save, %s to cancel",
+			styleKey.Render("Enter"), styleKey.Render("Esc")))
+	}
+
+	if m.wizardStep < addStepConfirm {
+		lines = append(lines, styleDim.Render("    Esc to cancel"))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m RoutingModel) renderEditUsersOverlay() string {
+	row := m.mappings[m.selectedRow]
+	var lines []string
+	lines = append(lines, styleBold.Render(fmt.Sprintf("  Edit allowed users for %s:%s", row.Channel, row.ChatID)))
+	lines = append(lines, fmt.Sprintf("  Allowed senders: %s", m.editUsersInput.View()))
+	lines = append(lines, styleHint.Render("    Comma-separated user IDs. This replaces the current list."))
+	lines = append(lines, styleDim.Render("    Enter to save, Esc to cancel"))
+	return strings.Join(lines, "\n")
+}
+
+func (m RoutingModel) renderFolderBrowser() string {
+	var lines []string
+	lines = append(lines, styleBold.Render("  Browse Folders"))
+	lines = append(lines, fmt.Sprintf("  %s %s", styleDim.Render("Location:"), styleValue.Render(m.browserPath)))
+	lines = append(lines, "")
+
+	if m.browserLoading {
+		lines = append(lines, styleDim.Render("  Loading..."))
+	} else if m.browserErr != "" {
+		lines = append(lines, styleErr.Render("  "+m.browserErr))
+	} else {
+		// Build selectable list: [0] = "..", [1..N] = dirs, [N+1] = "[Select this folder]"
+		items := []string{".."}
+		items = append(items, m.browserEntries...)
+		items = append(items, "[Select this folder]")
+
+		maxVisible := 12
+		start := 0
+		if m.browserCursor > maxVisible-3 {
+			start = m.browserCursor - maxVisible + 3
+		}
+		end := start + maxVisible
+		if end > len(items) {
+			end = len(items)
+		}
+
+		for i := start; i < end; i++ {
+			indicator := "  "
+			if i == m.browserCursor {
+				indicator = styleBold.Foreground(colorAccent).Render("> ")
+			}
+			name := items[i]
+			if i > 0 && i < len(items)-1 {
+				name += "/"
+			}
+			line := fmt.Sprintf("    %s%s", indicator, name)
+			if i == m.browserCursor {
+				line = lipgloss.NewStyle().
+					Background(lipgloss.Color("#2A2A4A")).
+					Render(line)
+			}
+			lines = append(lines, line)
+		}
+		if end < len(items) {
+			lines = append(lines, styleDim.Render(fmt.Sprintf("    ... %d more", len(items)-end)))
+		}
+	}
+
+	lines = append(lines, "")
+	lines = append(lines, fmt.Sprintf("  %s Navigate   %s Enter/Select   %s Select current   %s Back",
+		styleKey.Render("j/k"),
+		styleKey.Render("Enter"),
+		styleKey.Render("Space"),
+		styleKey.Render("Esc"),
+	))
+
+	return strings.Join(lines, "\n")
+}
+
+func (m RoutingModel) renderDiscordPicker() string {
+	var lines []string
+	lines = append(lines, styleBold.Render("  Select Discord Channel"))
+	lines = append(lines, "")
+
+	if m.roomsLoading {
+		lines = append(lines, styleDim.Render("  Fetching servers and channels..."))
+	} else if m.roomsErr != "" {
+		lines = append(lines, styleErr.Render("  "+m.roomsErr))
+		lines = append(lines, "")
+		lines = append(lines, fmt.Sprintf("  %s Enter ID manually   %s Cancel",
+			styleKey.Render("[m]"), styleKey.Render("Esc")))
+	} else {
+		maxVisible := 12
+		start := 0
+		if m.roomCursor > maxVisible-3 {
+			start = m.roomCursor - maxVisible + 3
+		}
+		end := start + maxVisible
+		if end > len(m.discordRooms) {
+			end = len(m.discordRooms)
+		}
+
+		lastGuild := ""
+		for i := start; i < end; i++ {
+			room := m.discordRooms[i]
+			if room.GuildName != lastGuild {
+				if lastGuild != "" {
+					lines = append(lines, "")
+				}
+				lines = append(lines, "  "+styleBold.Render(room.GuildName))
+				lastGuild = room.GuildName
+			}
+			indicator := "  "
+			if i == m.roomCursor {
+				indicator = styleBold.Foreground(colorAccent).Render("> ")
+			}
+			line := fmt.Sprintf("    %s%s", indicator, room.ChannelName)
+			if i == m.roomCursor {
+				line = lipgloss.NewStyle().
+					Background(lipgloss.Color("#2A2A4A")).
+					Render(line)
+			}
+			lines = append(lines, line)
+		}
+		if end < len(m.discordRooms) {
+			lines = append(lines, styleDim.Render(fmt.Sprintf("    ... %d more", len(m.discordRooms)-end)))
+		}
+
+		lines = append(lines, "")
+		lines = append(lines, fmt.Sprintf("  %s Navigate   %s Select   %s Enter ID manually   %s Cancel",
+			styleKey.Render("j/k"),
+			styleKey.Render("Enter"),
+			styleKey.Render("[m]"),
+			styleKey.Render("Esc"),
+		))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func (m RoutingModel) renderTelegramPairing() string {
+	var lines []string
+	lines = append(lines, styleBold.Render("  Telegram Pairing"))
+	lines = append(lines, "")
+	lines = append(lines, "  Send a message from the Telegram chat you want to route.")
+	lines = append(lines, styleDim.Render("  Listening for messages... (15 second timeout)"))
+	lines = append(lines, "")
+	lines = append(lines, fmt.Sprintf("  %s Cancel", styleKey.Render("Esc")))
+	return strings.Join(lines, "\n")
 }

--- a/cmd/picoclaw/tui/tab_settings.go
+++ b/cmd/picoclaw/tui/tab_settings.go
@@ -1,0 +1,466 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type settingsMode int
+
+const (
+	settingsNormal  settingsMode = iota
+	settingsEditing              // text input active
+)
+
+// settingsDataMsg carries parsed config values.
+type settingsDataMsg struct {
+	discordEnabled   bool
+	telegramEnabled  bool
+	routingEnabled   bool
+	unmappedBehavior string
+	defaultModel     string
+	reasoningEffort  string
+	err              error
+}
+
+type settingKind int
+
+const (
+	settingReadonly settingKind = iota
+	settingBool
+	settingEnum
+	settingText
+)
+
+type settingRow struct {
+	key     string
+	label   string
+	value   string
+	kind    settingKind
+	options []string // valid values for enums
+	section string   // section header (set on first row of each section)
+}
+
+// SettingsModel handles the Settings tab.
+type SettingsModel struct {
+	exec        Executor
+	mode        settingsMode
+	loaded      bool
+	selectedRow int
+
+	// Editable config values
+	discordEnabled   bool
+	telegramEnabled  bool
+	routingEnabled   bool
+	unmappedBehavior string
+	defaultModel     string
+	reasoningEffort  string
+
+	vp     viewport.Model
+	width  int
+	height int
+
+	// Text editing
+	input   textinput.Model
+	editKey string
+
+	// Flash feedback
+	flashMsg   string
+	flashUntil time.Time
+}
+
+func NewSettingsModel(exec Executor) SettingsModel {
+	ti := textinput.New()
+	ti.CharLimit = 100
+	ti.Width = 40
+
+	vp := viewport.New(60, 10)
+	vp.KeyMap = viewport.KeyMap{}
+
+	return SettingsModel{
+		exec:  exec,
+		input: ti,
+		vp:    vp,
+	}
+}
+
+func (m *SettingsModel) AutoRun() tea.Cmd {
+	if !m.loaded {
+		return fetchSettingsData(m.exec)
+	}
+	return nil
+}
+
+func (m *SettingsModel) HandleData(msg settingsDataMsg) {
+	m.loaded = true
+	if msg.err != nil {
+		return
+	}
+	m.discordEnabled = msg.discordEnabled
+	m.telegramEnabled = msg.telegramEnabled
+	m.routingEnabled = msg.routingEnabled
+	m.unmappedBehavior = msg.unmappedBehavior
+	m.defaultModel = msg.defaultModel
+	m.reasoningEffort = msg.reasoningEffort
+}
+
+func (m *SettingsModel) HandleResize(width, height int) {
+	m.width = width
+	m.height = height
+	w := width - 8
+	if w > 96 {
+		w = 96
+	}
+	if w < 40 {
+		w = 40
+	}
+	avail := height - 10
+	if avail < 6 {
+		avail = 6
+	}
+	m.vp.Width = w
+	m.vp.Height = avail
+}
+
+func (m SettingsModel) buildDisplayRows(snap *VMSnapshot) []settingRow {
+	effortDisplay := m.reasoningEffort
+	if effortDisplay == "" {
+		effortDisplay = "default"
+	}
+
+	rows := []settingRow{
+		{key: "discord_enabled", label: "Discord", value: boolYesNo(m.discordEnabled), kind: settingBool, section: "Channels"},
+		{key: "telegram_enabled", label: "Telegram", value: boolYesNo(m.telegramEnabled), kind: settingBool},
+		{key: "routing_enabled", label: "Routing", value: boolYesNo(m.routingEnabled), kind: settingBool, section: "Routing"},
+		{key: "unmapped_behavior", label: "Unmapped behavior", value: m.unmappedBehavior, kind: settingEnum, options: []string{"block", "default"}},
+		{key: "default_model", label: "Default model", value: m.defaultModel, kind: settingText, section: "Agent"},
+		{key: "reasoning_effort", label: "Reasoning effort", value: effortDisplay, kind: settingEnum, options: []string{"", "low", "medium", "high"}},
+	}
+	if snap != nil {
+		rows = append(rows,
+			settingRow{key: "svc_installed", label: "Installed", value: boolYesNo(snap.ServiceInstalled), kind: settingReadonly, section: "Service"},
+			settingRow{key: "svc_running", label: "Running", value: boolYesNo(snap.ServiceRunning), kind: settingReadonly},
+			settingRow{key: "workspace", label: "Workspace", value: snap.WorkspacePath, kind: settingReadonly, section: "General"},
+		)
+	}
+	return rows
+}
+
+func boolYesNo(b bool) string {
+	if b {
+		return "Yes"
+	}
+	return "No"
+}
+
+// --- Update ---
+
+func (m SettingsModel) Update(msg tea.KeyMsg, snap *VMSnapshot) (SettingsModel, tea.Cmd) {
+	key := msg.String()
+	rows := m.buildDisplayRows(snap)
+
+	if m.mode == settingsEditing {
+		switch key {
+		case "esc":
+			m.mode = settingsNormal
+			m.input.Blur()
+			return m, nil
+		case "enter":
+			val := strings.TrimSpace(m.input.Value())
+			m.mode = settingsNormal
+			m.input.Blur()
+			if val != "" {
+				return m, m.applyTextEdit(val)
+			}
+			return m, nil
+		}
+		var cmd tea.Cmd
+		m.input, cmd = m.input.Update(msg)
+		return m, cmd
+	}
+
+	switch key {
+	case "up", "k":
+		if m.selectedRow > 0 {
+			m.selectedRow--
+		}
+	case "down", "j":
+		if m.selectedRow < len(rows)-1 {
+			m.selectedRow++
+		}
+	case "enter", " ":
+		if m.selectedRow < len(rows) {
+			row := rows[m.selectedRow]
+			switch row.kind {
+			case settingBool:
+				return m, m.toggleBool(row.key)
+			case settingEnum:
+				return m, m.cycleEnum(row.key, row.value, row.options)
+			case settingText:
+				m.mode = settingsEditing
+				m.editKey = row.key
+				m.input.SetValue(row.value)
+				m.input.Focus()
+				return m, nil
+			}
+		}
+	case "l":
+		m.loaded = false
+		return m, fetchSettingsData(m.exec)
+	}
+	return m, nil
+}
+
+func (m *SettingsModel) toggleBool(key string) tea.Cmd {
+	switch key {
+	case "discord_enabled":
+		m.discordEnabled = !m.discordEnabled
+		m.setFlash("Discord", m.discordEnabled)
+		return settingsToggleChannel(m.exec, "discord", m.discordEnabled)
+	case "telegram_enabled":
+		m.telegramEnabled = !m.telegramEnabled
+		m.setFlash("Telegram", m.telegramEnabled)
+		return settingsToggleChannel(m.exec, "telegram", m.telegramEnabled)
+	case "routing_enabled":
+		m.routingEnabled = !m.routingEnabled
+		m.setFlash("Routing", m.routingEnabled)
+		return routingToggleCmd(m.exec, m.routingEnabled)
+	}
+	return nil
+}
+
+func (m *SettingsModel) cycleEnum(key, current string, options []string) tea.Cmd {
+	if len(options) == 0 {
+		return nil
+	}
+	idx := 0
+	for i, opt := range options {
+		display := opt
+		if opt == "" {
+			display = "default"
+		}
+		if display == current {
+			idx = i
+			break
+		}
+	}
+	next := options[(idx+1)%len(options)]
+
+	switch key {
+	case "unmapped_behavior":
+		m.unmappedBehavior = next
+		m.flashMsg = styleOK.Render("✓") + " Unmapped behavior: " + next
+		m.flashUntil = time.Now().Add(3 * time.Second)
+		return settingsSetConfig(m.exec, []string{"routing", "unmapped_behavior"}, next)
+	case "reasoning_effort":
+		m.reasoningEffort = next
+		display := next
+		if display == "" {
+			display = "default"
+		}
+		m.flashMsg = styleOK.Render("✓") + " Reasoning effort: " + display
+		m.flashUntil = time.Now().Add(3 * time.Second)
+		return settingsSetConfig(m.exec, []string{"agents", "defaults", "reasoning_effort"}, next)
+	}
+	return nil
+}
+
+func (m *SettingsModel) applyTextEdit(value string) tea.Cmd {
+	switch m.editKey {
+	case "default_model":
+		m.defaultModel = value
+		m.flashMsg = styleOK.Render("✓") + " Model: " + value
+		m.flashUntil = time.Now().Add(3 * time.Second)
+		return settingsSetConfig(m.exec, []string{"agents", "defaults", "model"}, value)
+	}
+	return nil
+}
+
+func (m *SettingsModel) setFlash(name string, enabled bool) {
+	action := "disabled"
+	if enabled {
+		action = "enabled"
+	}
+	m.flashMsg = styleOK.Render("✓") + " " + name + " " + action
+	m.flashUntil = time.Now().Add(3 * time.Second)
+}
+
+// --- View ---
+
+func (m SettingsModel) View(snap *VMSnapshot, width int) string {
+	panelW := width - 4
+	if panelW > 100 {
+		panelW = 100
+	}
+	if panelW < 40 {
+		panelW = 40
+	}
+
+	if !m.loaded {
+		return "\n  Loading settings...\n"
+	}
+
+	rows := m.buildDisplayRows(snap)
+	var lines []string
+	lastSection := ""
+
+	for i, row := range rows {
+		if row.section != "" && row.section != lastSection {
+			if lastSection != "" {
+				lines = append(lines, "")
+			}
+			lines = append(lines, fmt.Sprintf("  %s", styleBold.Foreground(colorTitle).Render(row.section)))
+			lastSection = row.section
+		}
+
+		indicator := "  "
+		if i == m.selectedRow && m.mode == settingsNormal {
+			indicator = styleBold.Foreground(colorAccent).Render("▸ ")
+		}
+
+		valStr := row.value
+		switch row.kind {
+		case settingBool:
+			if row.value == "Yes" {
+				valStr = styleOK.Render("Yes")
+			} else {
+				valStr = styleErr.Render("No")
+			}
+		case settingReadonly:
+			if row.value == "Yes" {
+				valStr = styleOK.Render("Yes")
+			} else if row.value == "No" {
+				valStr = styleErr.Render("No")
+			} else if row.value == "" {
+				valStr = styleDim.Render("not set")
+			} else {
+				valStr = styleDim.Render(row.value)
+			}
+		case settingEnum, settingText:
+			if row.value == "" {
+				valStr = styleDim.Render("not set")
+			} else {
+				valStr = styleValue.Render(row.value)
+			}
+		}
+
+		labelStyle := lipgloss.NewStyle().Foreground(colorMuted).Width(20)
+		line := fmt.Sprintf("  %s%s  %s", indicator, labelStyle.Render(row.label), valStr)
+
+		if i == m.selectedRow && m.mode == settingsNormal {
+			line = lipgloss.NewStyle().
+				Background(lipgloss.Color("#2A2A4A")).
+				Width(panelW - 4).
+				Render(line)
+		}
+
+		lines = append(lines, line)
+	}
+
+	content := strings.Join(lines, "\n")
+	m.vp.SetContent(content)
+
+	var b strings.Builder
+	panel := stylePanel.Width(panelW).Render(m.vp.View())
+	title := stylePanelTitle.Render("Settings")
+	b.WriteString(placePanelTitle(panel, title))
+
+	// Keybindings
+	b.WriteString(fmt.Sprintf("  %s Toggle / Edit   %s Refresh\n",
+		styleKey.Render("[Enter]"),
+		styleKey.Render("[l]"),
+	))
+
+	// Text editing overlay
+	if m.mode == settingsEditing {
+		b.WriteString("\n")
+		editLabel := m.editKey
+		if m.editKey == "default_model" {
+			editLabel = "Model"
+		}
+		b.WriteString(fmt.Sprintf("  %s: %s\n", styleBold.Render(editLabel), m.input.View()))
+		b.WriteString(styleDim.Render("    Enter to save, Esc to cancel") + "\n")
+	}
+
+	// Flash message
+	if !m.flashUntil.IsZero() && time.Now().Before(m.flashUntil) {
+		b.WriteString("  " + m.flashMsg + "\n")
+	}
+
+	return b.String()
+}
+
+// --- Commands ---
+
+func fetchSettingsData(exec Executor) tea.Cmd {
+	return func() tea.Msg {
+		msg := settingsDataMsg{}
+		cfg, err := readConfigMap(exec)
+		if err != nil {
+			msg.err = err
+			return msg
+		}
+
+		if channels, ok := cfg["channels"].(map[string]interface{}); ok {
+			if discord, ok := channels["discord"].(map[string]interface{}); ok {
+				msg.discordEnabled, _ = discord["enabled"].(bool)
+			}
+			if telegram, ok := channels["telegram"].(map[string]interface{}); ok {
+				msg.telegramEnabled, _ = telegram["enabled"].(bool)
+			}
+		}
+
+		if agents, ok := cfg["agents"].(map[string]interface{}); ok {
+			if defaults, ok := agents["defaults"].(map[string]interface{}); ok {
+				msg.defaultModel, _ = defaults["model"].(string)
+				msg.reasoningEffort, _ = defaults["reasoning_effort"].(string)
+			}
+		}
+
+		if routing, ok := cfg["routing"].(map[string]interface{}); ok {
+			msg.routingEnabled, _ = routing["enabled"].(bool)
+			msg.unmappedBehavior, _ = routing["unmapped_behavior"].(string)
+		}
+		if msg.unmappedBehavior == "" {
+			msg.unmappedBehavior = "block"
+		}
+
+		return msg
+	}
+}
+
+func settingsToggleChannel(exec Executor, channel string, enabled bool) tea.Cmd {
+	return func() tea.Msg {
+		cfg, err := readConfigMap(exec)
+		if err != nil {
+			cfg = map[string]interface{}{}
+		}
+		channels := ensureMap(cfg, "channels")
+		ch := ensureMap(channels, channel)
+		ch["enabled"] = enabled
+		_ = writeConfigMap(exec, cfg)
+		return actionDoneMsg{output: channel + " toggled"}
+	}
+}
+
+func settingsSetConfig(exec Executor, path []string, value interface{}) tea.Cmd {
+	return func() tea.Msg {
+		cfg, err := readConfigMap(exec)
+		if err != nil {
+			cfg = map[string]interface{}{}
+		}
+		current := cfg
+		for _, key := range path[:len(path)-1] {
+			current = ensureMap(current, key)
+		}
+		current[path[len(path)-1]] = value
+		_ = writeConfigMap(exec, cfg)
+		return actionDoneMsg{output: "Updated " + path[len(path)-1]}
+	}
+}

--- a/cmd/picoclaw/tui/tab_skills.go
+++ b/cmd/picoclaw/tui/tab_skills.go
@@ -88,6 +88,9 @@ func (m *SkillsModel) HandleResize(width, height int) {
 	m.width = width
 	m.height = height
 	w := width - 8
+	if w > 96 {
+		w = 96
+	}
 	if w < 40 {
 		w = 40
 	}
@@ -323,6 +326,9 @@ func (m SkillsModel) Update(msg tea.KeyMsg, snap *VMSnapshot) (SkillsModel, tea.
 
 func (m SkillsModel) View(snap *VMSnapshot, width int) string {
 	panelW := width - 4
+	if panelW > 100 {
+		panelW = 100
+	}
 	if panelW < 40 {
 		panelW = 40
 	}

--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -16,6 +16,7 @@ import (
 
 type ContextBuilder struct {
 	workspace    string
+	version      string
 	skillsLoader *skills.SkillsLoader
 	memory       *MemoryStore
 	tools        *tools.ToolRegistry // Direct reference to tool registry
@@ -48,6 +49,11 @@ func (cb *ContextBuilder) SetToolsRegistry(registry *tools.ToolRegistry) {
 	cb.tools = registry
 }
 
+// SetVersion sets the runtime version for inclusion in the system prompt.
+func (cb *ContextBuilder) SetVersion(v string) {
+	cb.version = v
+}
+
 func (cb *ContextBuilder) getIdentity() string {
 	now := time.Now().Format("2006-01-02 15:04 (Monday)")
 	workspacePath, _ := filepath.Abs(filepath.Join(cb.workspace))
@@ -56,9 +62,14 @@ func (cb *ContextBuilder) getIdentity() string {
 	// Build tools section dynamically
 	toolsSection := cb.buildToolsSection()
 
-	return fmt.Sprintf(`# sciClaw
+	versionStr := cb.version
+	if versionStr == "" {
+		versionStr = "dev"
+	}
 
-You are sciClaw, a paired-scientist assistant built as a PicoClaw-compatible fork.
+	return fmt.Sprintf(`# sciClaw v%s
+
+You are sciClaw v%s, a paired-scientist assistant built as a PicoClaw-compatible fork.
 
 ## Current Time
 %s
@@ -82,7 +93,7 @@ Your workspace is at: %s
 3. **Memory** - When remembering something, write to %s/memory/MEMORY.md
 
 4. **Reproducibility** - Prefer idempotent actions and report assumptions/uncertainty.`,
-		now, runtime, workspacePath, workspacePath, workspacePath, toolsSection, workspacePath)
+		versionStr, versionStr, now, runtime, workspacePath, workspacePath, workspacePath, toolsSection, workspacePath)
 }
 
 func (cb *ContextBuilder) buildToolsSection() string {

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -31,6 +31,10 @@ import (
 	"github.com/sipeed/picoclaw/pkg/utils"
 )
 
+// Version is set by the main package at startup to inject the build version
+// into agent system prompts.
+var Version string
+
 type AgentLoop struct {
 	bus             *bus.MessageBus
 	provider        providers.LLMProvider
@@ -152,6 +156,7 @@ func NewAgentLoop(cfg *config.Config, msgBus *bus.MessageBus, provider providers
 	// Create context builder and set tools registry
 	contextBuilder := NewContextBuilder(workspace)
 	contextBuilder.SetToolsRegistry(toolsRegistry)
+	contextBuilder.SetVersion(Version)
 
 	var hookDispatcher *hooks.Dispatcher
 	hookAuditPath := ""

--- a/pkg/auth/op_vault.go
+++ b/pkg/auth/op_vault.go
@@ -1,0 +1,434 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	opKeyAccessToken = "access_token"
+	opKeyRefresh     = "refresh_token"
+	opKeyAccountID   = "account_id"
+	opKeyAuthMethod  = "auth_method"
+	opKeyExpiresAt   = "expires_at"
+	opKeyExpiresIn   = "expires_in"
+	opKeyProvider    = "provider"
+)
+
+// ParseOPItemCredential parses either a direct credential JSON object or a
+// 1Password item JSON payload and returns an AuthCredential.
+func ParseOPItemCredential(itemJSON []byte, provider string, defaultAuthMethod string) (*AuthCredential, error) {
+	var item map[string]interface{}
+	if err := json.Unmarshal(itemJSON, &item); err != nil {
+		return nil, fmt.Errorf("parsing item JSON: %w", err)
+	}
+
+	sources := []map[string]interface{}{
+		extractCredentialValuesFromObject(item),
+		extractCredentialValuesFromFields(item["fields"]),
+		extractCredentialValuesFromNotes(item["notesPlain"]),
+	}
+
+	accessToken := firstNonEmptyString(collectCandidateValues(sources, opKeyAccessToken))
+	if accessToken == "" {
+		return nil, fmt.Errorf("access token is required")
+	}
+
+	refreshToken := firstNonEmptyString(collectCandidateValues(sources, opKeyRefresh))
+	accountID := firstNonEmptyString(collectCandidateValues(sources, opKeyAccountID))
+
+	authMethod := firstNonEmptyString(collectCandidateValues(sources, opKeyAuthMethod))
+	if authMethod == "" {
+		if strings.TrimSpace(defaultAuthMethod) != "" {
+			authMethod = strings.TrimSpace(defaultAuthMethod)
+		} else {
+			authMethod = "oauth"
+		}
+	}
+
+	expiresAt, hasExpiresAt, err := parseExpiresAtCandidates(collectCandidateValues(sources, opKeyExpiresAt))
+	if err != nil {
+		return nil, err
+	}
+	if !hasExpiresAt {
+		expiresIn, hasExpiresIn, err := parseExpiresInCandidates(collectCandidateValues(sources, opKeyExpiresIn))
+		if err != nil {
+			return nil, err
+		}
+		if hasExpiresIn {
+			expiresAt = time.Now().Add(time.Duration(expiresIn) * time.Second)
+		}
+	}
+
+	credProvider := firstNonEmptyString(collectCandidateValues(sources, opKeyProvider))
+	if credProvider == "" {
+		credProvider = strings.TrimSpace(provider)
+	}
+
+	return &AuthCredential{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		AccountID:    accountID,
+		ExpiresAt:    expiresAt,
+		Provider:     credProvider,
+		AuthMethod:   authMethod,
+	}, nil
+}
+
+func extractCredentialValuesFromObject(obj map[string]interface{}) map[string]interface{} {
+	if len(obj) == 0 {
+		return nil
+	}
+
+	values := make(map[string]interface{})
+
+	if v, ok := findValueByAliases(obj, "access_token", "accessToken", "token"); ok {
+		values[opKeyAccessToken] = v
+	}
+	if v, ok := findValueByAliases(obj, "refresh_token", "refreshToken"); ok {
+		values[opKeyRefresh] = v
+	}
+	if v, ok := findValueByAliases(obj, "account_id", "accountId"); ok {
+		values[opKeyAccountID] = v
+	}
+	if v, ok := findValueByAliases(obj, "auth_method", "authMethod", "method"); ok {
+		values[opKeyAuthMethod] = v
+	}
+	if v, ok := findValueByAliases(obj, "expires_at", "expiresAt"); ok {
+		values[opKeyExpiresAt] = v
+	}
+	if v, ok := findValueByAliases(obj, "expires_in", "expiresIn"); ok {
+		values[opKeyExpiresIn] = v
+	}
+	if v, ok := findValueByAliases(obj, "provider"); ok {
+		values[opKeyProvider] = v
+	}
+
+	return values
+}
+
+func extractCredentialValuesFromFields(rawFields interface{}) map[string]interface{} {
+	fields, ok := rawFields.([]interface{})
+	if !ok || len(fields) == 0 {
+		return nil
+	}
+
+	values := make(map[string]interface{})
+	for _, field := range fields {
+		m, ok := field.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		fieldValue, hasValue := m["value"]
+		if !hasValue {
+			continue
+		}
+
+		for _, keyName := range []string{"id", "label", "title", "name"} {
+			key, ok := anyToString(m[keyName])
+			if !ok {
+				continue
+			}
+			credKey := canonicalCredentialKey(key)
+			if credKey == "" {
+				continue
+			}
+
+			if existing, exists := values[credKey]; !exists || isNilOrEmpty(existing) {
+				values[credKey] = fieldValue
+			}
+		}
+	}
+
+	return values
+}
+
+func extractCredentialValuesFromNotes(rawNotes interface{}) map[string]interface{} {
+	if rawNotes == nil {
+		return nil
+	}
+
+	if noteObj, ok := rawNotes.(map[string]interface{}); ok {
+		return extractCredentialValuesFromObject(noteObj)
+	}
+
+	notes, ok := anyToString(rawNotes)
+	if !ok {
+		return nil
+	}
+	notes = strings.TrimSpace(notes)
+	if notes == "" {
+		return nil
+	}
+
+	var noteObj map[string]interface{}
+	if err := json.Unmarshal([]byte(notes), &noteObj); err != nil {
+		return nil
+	}
+	return extractCredentialValuesFromObject(noteObj)
+}
+
+func collectCandidateValues(sources []map[string]interface{}, key string) []interface{} {
+	values := make([]interface{}, 0, len(sources))
+	for _, source := range sources {
+		if source == nil {
+			continue
+		}
+		if v, ok := source[key]; ok {
+			values = append(values, v)
+		}
+	}
+	return values
+}
+
+func firstNonEmptyString(values []interface{}) string {
+	for _, value := range values {
+		s, ok := anyToString(value)
+		if !ok {
+			continue
+		}
+		s = strings.TrimSpace(s)
+		if s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func findValueByAliases(obj map[string]interface{}, aliases ...string) (interface{}, bool) {
+	bestIndex := len(aliases) + 1
+	var bestValue interface{}
+	found := false
+
+	for k, v := range obj {
+		key := normalizeAliasKey(k)
+		for i, alias := range aliases {
+			if key == normalizeAliasKey(alias) && i < bestIndex {
+				bestIndex = i
+				bestValue = v
+				found = true
+			}
+		}
+	}
+
+	return bestValue, found
+}
+
+func canonicalCredentialKey(key string) string {
+	switch normalizeAliasKey(key) {
+	case "accesstoken", "token":
+		return opKeyAccessToken
+	case "refreshtoken":
+		return opKeyRefresh
+	case "accountid":
+		return opKeyAccountID
+	case "authmethod", "method":
+		return opKeyAuthMethod
+	case "expiresat":
+		return opKeyExpiresAt
+	case "expiresin":
+		return opKeyExpiresIn
+	case "provider":
+		return opKeyProvider
+	default:
+		return ""
+	}
+}
+
+func normalizeAliasKey(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + ('a' - 'A'))
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func parseExpiresAtCandidates(values []interface{}) (time.Time, bool, error) {
+	hadValue := false
+	var lastErr error
+
+	for _, value := range values {
+		if isNilOrEmpty(value) {
+			continue
+		}
+		hadValue = true
+
+		ts, err := parseExpiresAtValue(value)
+		if err == nil {
+			return ts, true, nil
+		}
+		lastErr = err
+	}
+
+	if hadValue {
+		if lastErr != nil {
+			return time.Time{}, false, fmt.Errorf("invalid expires_at: %w", lastErr)
+		}
+		return time.Time{}, false, fmt.Errorf("invalid expires_at")
+	}
+
+	return time.Time{}, false, nil
+}
+
+func parseExpiresAtValue(value interface{}) (time.Time, error) {
+	if s, ok := anyToString(value); ok {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return time.Time{}, fmt.Errorf("empty value")
+		}
+		if ts, err := time.Parse(time.RFC3339, s); err == nil {
+			return ts, nil
+		}
+		secs, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("expected RFC3339 or unix seconds")
+		}
+		return time.Unix(secs, 0).UTC(), nil
+	}
+
+	secs, err := anyToInt64(value)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(secs, 0).UTC(), nil
+}
+
+func parseExpiresInCandidates(values []interface{}) (int64, bool, error) {
+	hadValue := false
+	var lastErr error
+
+	for _, value := range values {
+		if isNilOrEmpty(value) {
+			continue
+		}
+		hadValue = true
+
+		secs, err := anyToInt64(value)
+		if err == nil {
+			return secs, true, nil
+		}
+		lastErr = err
+	}
+
+	if hadValue {
+		if lastErr != nil {
+			return 0, false, fmt.Errorf("invalid expires_in: %w", lastErr)
+		}
+		return 0, false, fmt.Errorf("invalid expires_in")
+	}
+
+	return 0, false, nil
+}
+
+func anyToString(value interface{}) (string, bool) {
+	switch v := value.(type) {
+	case string:
+		return v, true
+	case json.Number:
+		return v.String(), true
+	case int:
+		return strconv.Itoa(v), true
+	case int8:
+		return strconv.FormatInt(int64(v), 10), true
+	case int16:
+		return strconv.FormatInt(int64(v), 10), true
+	case int32:
+		return strconv.FormatInt(int64(v), 10), true
+	case int64:
+		return strconv.FormatInt(v, 10), true
+	case uint:
+		return strconv.FormatUint(uint64(v), 10), true
+	case uint8:
+		return strconv.FormatUint(uint64(v), 10), true
+	case uint16:
+		return strconv.FormatUint(uint64(v), 10), true
+	case uint32:
+		return strconv.FormatUint(uint64(v), 10), true
+	case uint64:
+		return strconv.FormatUint(v, 10), true
+	case float64:
+		if v == float64(int64(v)) {
+			return strconv.FormatInt(int64(v), 10), true
+		}
+		return strconv.FormatFloat(v, 'f', -1, 64), true
+	case float32:
+		f64 := float64(v)
+		if f64 == float64(int64(f64)) {
+			return strconv.FormatInt(int64(f64), 10), true
+		}
+		return strconv.FormatFloat(f64, 'f', -1, 64), true
+	default:
+		return "", false
+	}
+}
+
+func anyToInt64(value interface{}) (int64, error) {
+	switch v := value.(type) {
+	case json.Number:
+		return v.Int64()
+	case int:
+		return int64(v), nil
+	case int8:
+		return int64(v), nil
+	case int16:
+		return int64(v), nil
+	case int32:
+		return int64(v), nil
+	case int64:
+		return v, nil
+	case uint:
+		return int64(v), nil
+	case uint8:
+		return int64(v), nil
+	case uint16:
+		return int64(v), nil
+	case uint32:
+		return int64(v), nil
+	case uint64:
+		if v > uint64(^uint64(0)>>1) {
+			return 0, fmt.Errorf("value overflows int64")
+		}
+		return int64(v), nil
+	case float64:
+		if v != float64(int64(v)) {
+			return 0, fmt.Errorf("not an integer")
+		}
+		return int64(v), nil
+	case float32:
+		f64 := float64(v)
+		if f64 != float64(int64(f64)) {
+			return 0, fmt.Errorf("not an integer")
+		}
+		return int64(f64), nil
+	case string:
+		s := strings.TrimSpace(v)
+		if s == "" {
+			return 0, fmt.Errorf("empty integer value")
+		}
+		return strconv.ParseInt(s, 10, 64)
+	default:
+		return 0, fmt.Errorf("unsupported integer type %T", value)
+	}
+}
+
+func isNilOrEmpty(value interface{}) bool {
+	if value == nil {
+		return true
+	}
+	if s, ok := value.(string); ok {
+		return strings.TrimSpace(s) == ""
+	}
+	return false
+}

--- a/pkg/auth/op_vault_test.go
+++ b/pkg/auth/op_vault_test.go
@@ -1,0 +1,151 @@
+package auth
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseOPItemCredential_DirectObject(t *testing.T) {
+	expiresAt := time.Date(2030, time.January, 1, 12, 0, 0, 0, time.UTC)
+
+	item := map[string]interface{}{
+		"accessToken":  "direct-access-token",
+		"refreshToken": "direct-refresh-token",
+		"accountId":    "acct-direct",
+		"authMethod":   "custom-method",
+		"expiresAt":    expiresAt.Format(time.RFC3339),
+		"provider":     "provider-in-item",
+	}
+	body, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	cred, err := ParseOPItemCredential(body, "provider-arg", "oauth")
+	if err != nil {
+		t.Fatalf("ParseOPItemCredential() error = %v", err)
+	}
+
+	if cred.AccessToken != "direct-access-token" {
+		t.Errorf("AccessToken = %q, want %q", cred.AccessToken, "direct-access-token")
+	}
+	if cred.RefreshToken != "direct-refresh-token" {
+		t.Errorf("RefreshToken = %q, want %q", cred.RefreshToken, "direct-refresh-token")
+	}
+	if cred.AccountID != "acct-direct" {
+		t.Errorf("AccountID = %q, want %q", cred.AccountID, "acct-direct")
+	}
+	if cred.AuthMethod != "custom-method" {
+		t.Errorf("AuthMethod = %q, want %q", cred.AuthMethod, "custom-method")
+	}
+	if !cred.ExpiresAt.Equal(expiresAt) {
+		t.Errorf("ExpiresAt = %s, want %s", cred.ExpiresAt.Format(time.RFC3339), expiresAt.Format(time.RFC3339))
+	}
+	if cred.Provider != "provider-in-item" {
+		t.Errorf("Provider = %q, want %q", cred.Provider, "provider-in-item")
+	}
+}
+
+func TestParseOPItemCredential_FieldsAliases(t *testing.T) {
+	item := map[string]interface{}{
+		"fields": []map[string]interface{}{
+			{"id": "token", "value": "field-access-token"},
+			{"label": "refreshToken", "value": "field-refresh-token"},
+			{"id": "account_id", "value": "acct-field"},
+			{"label": "expires_at", "value": "1893456000"},
+		},
+	}
+	body, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	cred, err := ParseOPItemCredential(body, "provider-arg", "default-method")
+	if err != nil {
+		t.Fatalf("ParseOPItemCredential() error = %v", err)
+	}
+
+	if cred.AccessToken != "field-access-token" {
+		t.Errorf("AccessToken = %q, want %q", cred.AccessToken, "field-access-token")
+	}
+	if cred.RefreshToken != "field-refresh-token" {
+		t.Errorf("RefreshToken = %q, want %q", cred.RefreshToken, "field-refresh-token")
+	}
+	if cred.AccountID != "acct-field" {
+		t.Errorf("AccountID = %q, want %q", cred.AccountID, "acct-field")
+	}
+	if cred.AuthMethod != "default-method" {
+		t.Errorf("AuthMethod = %q, want %q", cred.AuthMethod, "default-method")
+	}
+	if cred.Provider != "provider-arg" {
+		t.Errorf("Provider = %q, want %q", cred.Provider, "provider-arg")
+	}
+	if cred.ExpiresAt.Unix() != 1893456000 {
+		t.Errorf("ExpiresAt.Unix() = %d, want %d", cred.ExpiresAt.Unix(), int64(1893456000))
+	}
+}
+
+func TestParseOPItemCredential_NotesPlainJSON(t *testing.T) {
+	notesObj := map[string]interface{}{
+		"access_token":  "notes-access-token",
+		"refresh_token": "notes-refresh-token",
+		"expiresIn":     "120",
+	}
+	notesJSON, err := json.Marshal(notesObj)
+	if err != nil {
+		t.Fatalf("json.Marshal(notesObj) error = %v", err)
+	}
+
+	item := map[string]interface{}{
+		"notesPlain": string(notesJSON),
+	}
+	body, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("json.Marshal(item) error = %v", err)
+	}
+
+	start := time.Now()
+	cred, err := ParseOPItemCredential(body, "provider-arg", "")
+	end := time.Now()
+	if err != nil {
+		t.Fatalf("ParseOPItemCredential() error = %v", err)
+	}
+
+	if cred.AccessToken != "notes-access-token" {
+		t.Errorf("AccessToken = %q, want %q", cred.AccessToken, "notes-access-token")
+	}
+	if cred.RefreshToken != "notes-refresh-token" {
+		t.Errorf("RefreshToken = %q, want %q", cred.RefreshToken, "notes-refresh-token")
+	}
+	if cred.AuthMethod != "oauth" {
+		t.Errorf("AuthMethod = %q, want %q", cred.AuthMethod, "oauth")
+	}
+	if cred.Provider != "provider-arg" {
+		t.Errorf("Provider = %q, want %q", cred.Provider, "provider-arg")
+	}
+	if cred.ExpiresAt.Before(start.Add(110*time.Second)) || cred.ExpiresAt.After(end.Add(130*time.Second)) {
+		t.Errorf("ExpiresAt = %s, expected near now + 120s", cred.ExpiresAt.Format(time.RFC3339))
+	}
+}
+
+func TestParseOPItemCredential_MissingTokenError(t *testing.T) {
+	item := map[string]interface{}{
+		"fields": []map[string]interface{}{
+			{"id": "refresh_token", "value": "only-refresh-token"},
+		},
+	}
+	body, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	_, err = ParseOPItemCredential(body, "provider-arg", "oauth")
+	if err == nil {
+		t.Fatal("ParseOPItemCredential() error = nil, want non-nil")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "access token") {
+		t.Errorf("error = %q, want to contain %q", err.Error(), "access token")
+	}
+}

--- a/pkg/channels/base.go
+++ b/pkg/channels/base.go
@@ -47,7 +47,7 @@ func (c *BaseChannel) IsRunning() bool {
 
 func (c *BaseChannel) IsAllowed(senderID string) bool {
 	if len(c.allowList) == 0 {
-		return true
+		return false // no approved users → reject all messages
 	}
 
 	// Extract parts from compound senderID like "123456|username"


### PR DESCRIPTION
## Summary
- Routing tab: multi-step add-mapping wizard with Discord room picker, Telegram pairing flow, custom folder browser, inline edit-users overlay, and empty-state onboarding
- CLI: `channels list-rooms` and `channels pair-telegram` subcommands for programmatic channel discovery
- TUI: rename Agent → Gateway, add API key entry to Login, add Settings tab, cap routing panel width, fix channel security default
- New: 1Password vault auth support (`op_vault.go`)

## Test plan
- [ ] `sciclaw tui` — verify all tabs render
- [ ] Routing tab: `[a]` add wizard flow (Discord picker, Telegram pair, manual)
- [ ] Routing tab: `[u]` edit users overlay
- [ ] Routing tab: folder browser in workspace step
- [ ] Settings tab renders and saves
- [ ] `sciclaw channels list-rooms --channel discord`
- [ ] `sciclaw channels pair-telegram --timeout 5`
- [ ] `make build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)