### PR TITLE
feat(workspace): add shared workspace policy with read-only guardrails

### DIFF
--- a/pkg/agent/context_test.go
+++ b/pkg/agent/context_test.go
@@ -54,7 +54,7 @@ func TestLoadBootstrapFilesFallsBackToGlobalWorkspace(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	globalWorkspace := filepath.Join(home, ".picoclaw", "workspace")
+	globalWorkspace := filepath.Join(home, "sciclaw")
 	if err := os.MkdirAll(globalWorkspace, 0755); err != nil {
 		t.Fatalf("mkdir global workspace: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestContextBuilderLoadsGlobalWorkspaceSkillsForRoutedWorkspace(t *testing.T
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	skillDir := filepath.Join(home, ".picoclaw", "workspace", "skills", "baseline")
+	skillDir := filepath.Join(home, "sciclaw", "skills", "baseline")
 	if err := os.MkdirAll(skillDir, 0755); err != nil {
 		t.Fatalf("mkdir skill dir: %v", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,14 +61,16 @@ type AgentsConfig struct {
 }
 
 type AgentDefaults struct {
-	Workspace           string  `json:"workspace" env:"PICOCLAW_AGENTS_DEFAULTS_WORKSPACE"`
-	RestrictToWorkspace bool    `json:"restrict_to_workspace" env:"PICOCLAW_AGENTS_DEFAULTS_RESTRICT_TO_WORKSPACE"`
-	Provider            string  `json:"provider" env:"PICOCLAW_AGENTS_DEFAULTS_PROVIDER"`
-	Model               string  `json:"model" env:"PICOCLAW_AGENTS_DEFAULTS_MODEL"`
-	MaxTokens           int     `json:"max_tokens" env:"PICOCLAW_AGENTS_DEFAULTS_MAX_TOKENS"`
-	Temperature         float64 `json:"temperature" env:"PICOCLAW_AGENTS_DEFAULTS_TEMPERATURE"`
-	MaxToolIterations   int     `json:"max_tool_iterations" env:"PICOCLAW_AGENTS_DEFAULTS_MAX_TOOL_ITERATIONS"`
-	ReasoningEffort     string  `json:"reasoning_effort,omitempty" env:"PICOCLAW_AGENTS_DEFAULTS_REASONING_EFFORT"`
+	Workspace               string  `json:"workspace" env:"PICOCLAW_AGENTS_DEFAULTS_WORKSPACE"`
+	RestrictToWorkspace     bool    `json:"restrict_to_workspace" env:"PICOCLAW_AGENTS_DEFAULTS_RESTRICT_TO_WORKSPACE"`
+	SharedWorkspace         string  `json:"shared_workspace" env:"PICOCLAW_AGENTS_DEFAULTS_SHARED_WORKSPACE"`
+	SharedWorkspaceReadOnly bool    `json:"shared_workspace_read_only" env:"PICOCLAW_AGENTS_DEFAULTS_SHARED_WORKSPACE_READ_ONLY"`
+	Provider                string  `json:"provider" env:"PICOCLAW_AGENTS_DEFAULTS_PROVIDER"`
+	Model                   string  `json:"model" env:"PICOCLAW_AGENTS_DEFAULTS_MODEL"`
+	MaxTokens               int     `json:"max_tokens" env:"PICOCLAW_AGENTS_DEFAULTS_MAX_TOKENS"`
+	Temperature             float64 `json:"temperature" env:"PICOCLAW_AGENTS_DEFAULTS_TEMPERATURE"`
+	MaxToolIterations       int     `json:"max_tool_iterations" env:"PICOCLAW_AGENTS_DEFAULTS_MAX_TOOL_ITERATIONS"`
+	ReasoningEffort         string  `json:"reasoning_effort,omitempty" env:"PICOCLAW_AGENTS_DEFAULTS_REASONING_EFFORT"`
 }
 
 const (
@@ -236,13 +238,15 @@ func DefaultConfig() *Config {
 			Defaults: AgentDefaults{
 				// Keep config/auth under ~/.picoclaw for compatibility, but default the *workspace*
 				// to a visible directory for scientific users.
-				Workspace:           "~/sciclaw",
-				RestrictToWorkspace: true,
-				Provider:            "",
-				Model:               "gpt-5.2",
-				MaxTokens:           8192,
-				Temperature:         0.7,
-				MaxToolIterations:   0, // 0 = no hard iteration cap
+				Workspace:               "~/sciclaw",
+				RestrictToWorkspace:     true,
+				SharedWorkspace:         "~/sciclaw",
+				SharedWorkspaceReadOnly: true,
+				Provider:                "",
+				Model:                   "gpt-5.2",
+				MaxTokens:               8192,
+				Temperature:             0.7,
+				MaxToolIterations:       0, // 0 = no hard iteration cap
 			},
 		},
 		Channels: ChannelsConfig{
@@ -406,6 +410,12 @@ func (c *Config) WorkspacePath() string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return expandHome(c.Agents.Defaults.Workspace)
+}
+
+func (c *Config) SharedWorkspacePath() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return expandHome(c.Agents.Defaults.SharedWorkspace)
 }
 
 func (c *Config) GetAPIKey() string {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -24,6 +25,19 @@ func TestDefaultConfig_WorkspacePath(t *testing.T) {
 	// since expandHome behavior may differ based on environment
 	if cfg.Agents.Defaults.Workspace == "" {
 		t.Error("Workspace should not be empty")
+	}
+	if cfg.Agents.Defaults.SharedWorkspace == "" {
+		t.Error("SharedWorkspace should not be empty")
+	}
+	if !cfg.Agents.Defaults.SharedWorkspaceReadOnly {
+		t.Error("SharedWorkspaceReadOnly should default to true")
+	}
+}
+
+func TestDefaultConfig_SharedWorkspacePath(t *testing.T) {
+	cfg := DefaultConfig()
+	if strings.TrimSpace(cfg.SharedWorkspacePath()) == "" {
+		t.Fatal("SharedWorkspacePath should not be empty")
 	}
 }
 

--- a/pkg/tools/edit.go
+++ b/pkg/tools/edit.go
@@ -10,8 +10,10 @@ import (
 // EditFileTool edits a file by replacing old_text with new_text.
 // The old_text must exist exactly in the file.
 type EditFileTool struct {
-	allowedDir string
-	restrict   bool
+	allowedDir              string
+	restrict                bool
+	sharedWorkspace         string
+	sharedWorkspaceReadOnly bool
 }
 
 // NewEditFileTool creates a new EditFileTool with optional directory restriction.
@@ -20,6 +22,11 @@ func NewEditFileTool(allowedDir string, restrict bool) *EditFileTool {
 		allowedDir: allowedDir,
 		restrict:   restrict,
 	}
+}
+
+func (t *EditFileTool) SetSharedWorkspacePolicy(sharedWorkspace string, sharedWorkspaceReadOnly bool) {
+	t.sharedWorkspace = strings.TrimSpace(sharedWorkspace)
+	t.sharedWorkspaceReadOnly = sharedWorkspaceReadOnly
 }
 
 func (t *EditFileTool) Name() string {
@@ -67,7 +74,7 @@ func (t *EditFileTool) Execute(ctx context.Context, args map[string]interface{})
 		return ErrorResult("new_text is required")
 	}
 
-	resolvedPath, err := validatePath(path, t.allowedDir, t.restrict)
+	resolvedPath, err := validatePathWithPolicy(path, t.allowedDir, t.restrict, AccessWrite, t.sharedWorkspace, t.sharedWorkspaceReadOnly)
 	if err != nil {
 		return ErrorResult(err.Error())
 	}
@@ -102,12 +109,19 @@ func (t *EditFileTool) Execute(ctx context.Context, args map[string]interface{})
 }
 
 type AppendFileTool struct {
-	workspace string
-	restrict  bool
+	workspace               string
+	restrict                bool
+	sharedWorkspace         string
+	sharedWorkspaceReadOnly bool
 }
 
 func NewAppendFileTool(workspace string, restrict bool) *AppendFileTool {
 	return &AppendFileTool{workspace: workspace, restrict: restrict}
+}
+
+func (t *AppendFileTool) SetSharedWorkspacePolicy(sharedWorkspace string, sharedWorkspaceReadOnly bool) {
+	t.sharedWorkspace = strings.TrimSpace(sharedWorkspace)
+	t.sharedWorkspaceReadOnly = sharedWorkspaceReadOnly
 }
 
 func (t *AppendFileTool) Name() string {
@@ -146,7 +160,7 @@ func (t *AppendFileTool) Execute(ctx context.Context, args map[string]interface{
 		return ErrorResult("content is required")
 	}
 
-	resolvedPath, err := validatePath(path, t.workspace, t.restrict)
+	resolvedPath, err := validatePathWithPolicy(path, t.workspace, t.restrict, AccessWrite, t.sharedWorkspace, t.sharedWorkspaceReadOnly)
 	if err != nil {
 		return ErrorResult(err.Error())
 	}

--- a/pkg/tools/message_test.go
+++ b/pkg/tools/message_test.go
@@ -272,7 +272,7 @@ func TestMessageTool_Execute_AttachmentOutsideWorkspaceBlocked(t *testing.T) {
 	if !result.IsError {
 		t.Fatal("expected error for outside-workspace attachment")
 	}
-	if !strings.Contains(result.ForLLM, "outside the workspace") {
+	if !strings.Contains(result.ForLLM, "outside allowed roots") {
 		t.Fatalf("expected workspace denial, got %q", result.ForLLM)
 	}
 }

--- a/pkg/tools/word_count.go
+++ b/pkg/tools/word_count.go
@@ -9,8 +9,10 @@ import (
 )
 
 type WordCountTool struct {
-	workspace string
-	restrict  bool
+	workspace               string
+	restrict                bool
+	sharedWorkspace         string
+	sharedWorkspaceReadOnly bool
 }
 
 func NewWordCountTool(workspace string, restrict bool) *WordCountTool {
@@ -18,6 +20,11 @@ func NewWordCountTool(workspace string, restrict bool) *WordCountTool {
 		workspace: workspace,
 		restrict:  restrict,
 	}
+}
+
+func (t *WordCountTool) SetSharedWorkspacePolicy(sharedWorkspace string, sharedWorkspaceReadOnly bool) {
+	t.sharedWorkspace = strings.TrimSpace(sharedWorkspace)
+	t.sharedWorkspaceReadOnly = sharedWorkspaceReadOnly
 }
 
 func (t *WordCountTool) Name() string {
@@ -55,7 +62,7 @@ func (t *WordCountTool) Execute(ctx context.Context, args map[string]interface{}
 
 	source := "text"
 	if strings.TrimSpace(path) != "" {
-		resolved, err := validatePath(path, t.workspace, t.restrict)
+		resolved, err := validatePathWithPolicy(path, t.workspace, t.restrict, AccessRead, t.sharedWorkspace, t.sharedWorkspaceReadOnly)
 		if err != nil {
 			return ErrorResult(err.Error())
 		}


### PR DESCRIPTION
## Summary\n- add shared workspace config defaults and path resolver\n- thread shared workspace policy into agent tool wiring\n- allow reads from shared workspace while enforcing read-only writes when configured\n- extend filesystem/shell/edit/message/word-count/pubmed-export tools with shared policy checks\n- update context fallback to prefer shared workspace skill paths\n- add tests for shared workspace read/write guard behavior\n\n## Validation\n- go test ./pkg/config ./pkg/agent ./pkg/tools\n- go test ./... (fails only in existing pkg/channels allowlist tests, unrelated)\n