### PR TITLE
fix(service): clear launchd disabled overrides before bootstrap

### DIFF
--- a/cmd/picoclaw/tui/tab_home.go
+++ b/cmd/picoclaw/tui/tab_home.go
@@ -195,7 +195,11 @@ func (m *HomeModel) HandleExecDone(msg onboardExecDoneMsg) {
 		m.onboardStep = wizardService
 	case wizardService:
 		if msg.err != nil {
-			m.onboardResult = "Service install failed: " + msg.err.Error()
+			detail := strings.TrimSpace(msg.output)
+			if detail == "" {
+				detail = msg.err.Error()
+			}
+			m.onboardResult = "err:Service install failed: " + detail
 		} else {
 			m.onboardResult = "Service installed and started."
 		}
@@ -389,8 +393,14 @@ func (m HomeModel) viewWizard(snap *VMSnapshot, width int) string {
 				"\n" +
 				"  " + styleDim.Render("This enables the background agent.") + "\n"
 		} else if m.onboardResult != "" {
+			icon := styleOK.Render("✓")
+			resultText := m.onboardResult
+			if strings.HasPrefix(m.onboardResult, "err:") {
+				icon = styleErr.Render("✗")
+				resultText = m.onboardResult[4:]
+			}
 			content = "\n" +
-				"  " + styleOK.Render("✓") + " " + m.onboardResult + "\n" +
+				"  " + icon + " " + resultText + "\n" +
 				"\n" +
 				"  " + styleDim.Render("Press Enter to continue.") + "\n"
 		} else {


### PR DESCRIPTION
## Summary
- `launchctl bootout` leaves the service label in launchd's disabled overrides database, causing subsequent `bootstrap` calls to fail with misleading "Input/output error"
- Fix: call `launchctl enable` before `bootstrap` in `Install()` and `Start()`, and after `bootout` in `Uninstall()` to prevent stale disabled state
- Fix wizard service step to show `✗` error icon (not `✓`) on failure, with actual command output

## Test plan
- [ ] `sciclaw service uninstall && sciclaw service install` succeeds on macOS
- [ ] Repeated uninstall/install cycles don't accumulate disabled overrides
- [ ] Wizard service step shows red error on failure, green check on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)