### PR TITLE
feat: per-user answer theme profiles with /theme slash command

### DIFF
--- a/cmd/picoclaw/main.go
+++ b/cmd/picoclaw/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/sipeed/picoclaw/pkg/phi"
 	"github.com/sipeed/picoclaw/pkg/providers"
 	"github.com/sipeed/picoclaw/pkg/routing"
+	"github.com/sipeed/picoclaw/pkg/profile"
 	svcmgr "github.com/sipeed/picoclaw/pkg/service"
 	"github.com/sipeed/picoclaw/pkg/skills"
 	"github.com/sipeed/picoclaw/pkg/tools"
@@ -1509,6 +1510,10 @@ func gatewayCmd() {
 	msgBus := bus.NewMessageBus()
 	agentLoop := agent.NewAgentLoop(cfg, msgBus, provider)
 
+	// Wire per-user profile store for answer theme resolution
+	gatewayProfileStore := profile.NewStore(filepath.Join(picoDir, "profiles"))
+	agentLoop.SetProfileStore(gatewayProfileStore)
+
 	// Print agent startup info
 	fmt.Println("\n📦 Agent Status:")
 	startupInfo := agentLoop.GetStartupInfo()
@@ -1605,6 +1610,9 @@ func gatewayCmd() {
 			dc.SetSlashSkillCatalogCallback(func(channelID, guildID, userID string) ([]channels.SlashSkillChoice, error) {
 				return listDiscordSlashSkills(cfg, channelID, guildID, userID)
 			})
+			dc.SetThemeHandler(func(senderID, displayName, theme string) error {
+				return gatewayProfileStore.SetAnswerTheme(senderID, displayName, theme)
+			})
 			logger.InfoC("tools", "Channel history tool attached to Discord")
 		}
 	}
@@ -1665,8 +1673,11 @@ func gatewayCmd() {
 			fmt.Printf("Error initializing routing: %v\n", err)
 			os.Exit(1)
 		}
-		// Build a setup function that wires channel_history for each routed agent loop.
+		// Build a setup function that wires channel_history and profile store for each routed agent loop.
 		var poolSetup []routing.LoopSetupFunc
+		poolSetup = append(poolSetup, func(al *agent.AgentLoop) {
+			al.SetProfileStore(gatewayProfileStore)
+		})
 		if channelHistoryCB != nil {
 			poolSetup = append(poolSetup, func(al *agent.AgentLoop) {
 				attachChannelHistoryCallback(al, channelHistoryCB)

--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -22,6 +22,29 @@ type ContextBuilder struct {
 	memory                     *MemoryStore
 	tools                      *tools.ToolRegistry // Direct reference to tool registry
 	includePromptToolSummaries bool
+
+	// Per-turn sender context (set before each BuildMessages call)
+	senderID    string
+	senderName  string
+	answerTheme string
+}
+
+// SetSenderContext sets per-turn sender identity and answer theme.
+// Call this before BuildMessages on each turn.
+func (cb *ContextBuilder) SetSenderContext(senderID, displayName, theme string) {
+	cb.senderID = senderID
+	// Sanitize display name: single line, bounded length, no control chars
+	name := strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\r' || r < 32 {
+			return ' '
+		}
+		return r
+	}, strings.TrimSpace(displayName))
+	if len(name) > 64 {
+		name = name[:64]
+	}
+	cb.senderName = name
+	cb.answerTheme = theme
 }
 
 func getGlobalConfigDir() string {
@@ -206,6 +229,17 @@ func (cb *ContextBuilder) BuildSystemPrompt() string {
 	bootstrapContent := cb.LoadBootstrapFiles()
 	if bootstrapContent != "" {
 		parts = append(parts, bootstrapContent)
+	}
+
+	// Active user profile (injected after bootstrap so theme definitions are in context)
+	if cb.answerTheme != "" {
+		userSection := "## Active User\n"
+		if cb.senderName != "" {
+			userSection += fmt.Sprintf("Name: %s\n", cb.senderName)
+		}
+		userSection += fmt.Sprintf("Answer Theme: %s\n\nIMPORTANT: Follow the %s theme rules from the Answer Themes section above.",
+			cb.answerTheme, cb.answerTheme)
+		parts = append(parts, userSection)
 	}
 
 	// Skills - show summary, AI can read full content with read_file tool

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -64,6 +64,17 @@ type AgentLoop struct {
 	turnCounter     uint64
 	running         atomic.Bool
 	summarizing     sync.Map // Tracks which sessions are currently being summarized
+	profileStore    ThemeResolver
+}
+
+// ThemeResolver looks up per-user answer theme preferences.
+type ThemeResolver interface {
+	AnswerTheme(senderID string) string
+}
+
+// SetProfileStore sets the per-user theme resolver.
+func (al *AgentLoop) SetProfileStore(store ThemeResolver) {
+	al.profileStore = store
 }
 
 type ToolProfile string
@@ -109,6 +120,8 @@ type processOptions struct {
 	NoHistory       bool   // If true, don't load session history (for heartbeat)
 	Ephemeral       bool   // If true, do not mutate session/state on disk
 	OnProgress      func(phase, detail string)
+	SenderID        string // Sender identifier for per-user profile lookup
+	SenderName      string // Sender display name (from channel metadata)
 }
 
 type userVisibleError interface {
@@ -682,6 +695,8 @@ func (al *AgentLoop) processMessageWithProgress(ctx context.Context, msg bus.Inb
 		SendResponse:    false,
 		Ephemeral:       al.toolProfile.isSideLane(),
 		OnProgress:      onProgress,
+		SenderID:        msg.Channel + ":" + msg.SenderID,
+		SenderName:      msg.Metadata["username"],
 	})
 	return result.FinalContent, err
 }
@@ -877,6 +892,13 @@ func (al *AgentLoop) runAgentLoop(ctx context.Context, opts processOptions) (llm
 				"artifact_chars":  len(artifactContext),
 				"user_prompt_len": len(userMessageForPrompt),
 			})
+	}
+	// Clear per-turn sender context to prevent leaking between users/turns,
+	// then resolve per-user answer theme if available.
+	al.contextBuilder.SetSenderContext("", "", "")
+	if opts.SenderID != "" && al.profileStore != nil {
+		theme := al.profileStore.AnswerTheme(opts.SenderID)
+		al.contextBuilder.SetSenderContext(opts.SenderID, opts.SenderName, theme)
 	}
 	messages := al.contextBuilder.BuildMessages(
 		history,

--- a/pkg/channels/discord.go
+++ b/pkg/channels/discord.go
@@ -70,8 +70,14 @@ type DiscordChannel struct {
 	createCommandFn       func(appID, guildID string, cmd *discordgo.ApplicationCommand) (*discordgo.ApplicationCommand, error)
 	editCommandFn         func(appID, guildID, cmdID string, cmd *discordgo.ApplicationCommand) (*discordgo.ApplicationCommand, error)
 	skillCatalogFn        func(channelID, guildID, userID string) ([]SlashSkillChoice, error)
+	themeSetFn            func(senderID, displayName, theme string) error
 	inboundMu             sync.Mutex
 	recentInbound         map[string]inboundMessageFingerprint
+}
+
+// SetThemeHandler sets the callback for the /theme slash command.
+func (c *DiscordChannel) SetThemeHandler(fn func(senderID, displayName, theme string) error) {
+	c.themeSetFn = fn
 }
 
 func NewDiscordChannel(cfg config.DiscordConfig, messageBus *bus.MessageBus) (*DiscordChannel, error) {
@@ -479,6 +485,26 @@ func buildSkillSlashCommand() *discordgo.ApplicationCommand {
 	}
 }
 
+func buildThemeSlashCommand() *discordgo.ApplicationCommand {
+	return &discordgo.ApplicationCommand{
+		Name:        "theme",
+		Description: "Set your answer theme (clear, formal, brief)",
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Name:        "style",
+				Description: "Answer theme to use",
+				Type:        discordgo.ApplicationCommandOptionString,
+				Required:    true,
+				Choices: []*discordgo.ApplicationCommandOptionChoice{
+					{Name: "Clear (default — plain language, dense prose)", Value: "clear"},
+					{Name: "Formal (academic, publication-ready)", Value: "formal"},
+					{Name: "Brief (3-5 sentences max)", Value: "brief"},
+				},
+			},
+		},
+	}
+}
+
 func interactionAuthor(i *discordgo.Interaction) *discordgo.User {
 	if i == nil {
 		return nil
@@ -620,7 +646,7 @@ func (c *DiscordChannel) ensureSlashCommands() error {
 		}
 		existingByName[existing.Name] = existing
 	}
-	for _, cmd := range []*discordgo.ApplicationCommand{buildBTWSlashCommand(), buildSkillSlashCommand()} {
+	for _, cmd := range []*discordgo.ApplicationCommand{buildBTWSlashCommand(), buildSkillSlashCommand(), buildThemeSlashCommand()} {
 		existing := existingByName[cmd.Name]
 		if existing == nil {
 			if _, err := c.createCommandFn(c.botUserID, "", cmd); err != nil {
@@ -670,6 +696,8 @@ func (c *DiscordChannel) handleInteractionCreate(_ *discordgo.Session, i *discor
 		c.handleBTWInteraction(i, data)
 	case "skill":
 		c.handleSkillInteraction(i, data)
+	case "theme":
+		c.handleThemeInteraction(i, data)
 	}
 }
 
@@ -820,6 +848,45 @@ func (c *DiscordChannel) handleSkillInteraction(i *discordgo.InteractionCreate, 
 	metadata := buildSlashMetadata(i.Interaction, data.Name, author)
 	metadata["requested_skill_name"] = selected.Name
 	c.publishSlashTask(i, author, skillSlashContent(selected.Name, prompt), metadata, fmt.Sprintf("Started. I’m using the skill %q and will reply in the channel below.", selected.Name))
+}
+
+func (c *DiscordChannel) handleThemeInteraction(i *discordgo.InteractionCreate, data discordgo.ApplicationCommandInteractionData) {
+	style := slashOptionString(data.Options, "style")
+	if style == "" {
+		c.respondInteractionEphemeral(i.Interaction, "Please select a theme.")
+		return
+	}
+	author := interactionAuthor(i.Interaction)
+	if author == nil {
+		return
+	}
+	if !c.IsAllowed(author.ID) {
+		c.respondInteractionEphemeral(i.Interaction, "You are not allowed to use this sciClaw bot.")
+		return
+	}
+	if c.themeSetFn == nil {
+		c.respondInteractionEphemeral(i.Interaction, "Theme preferences are not configured on this sciClaw instance.")
+		return
+	}
+	if err := c.themeSetFn("discord:"+author.ID, author.Username, style); err != nil {
+		c.respondInteractionEphemeral(i.Interaction, fmt.Sprintf("Failed to set theme: %v", err))
+		return
+	}
+	label := strings.ToUpper(style[:1]) + style[1:]
+	c.respondInteractionEphemeral(i.Interaction, fmt.Sprintf("Answer theme set to **%s**. I'll use this style for all your messages.", label))
+}
+
+func (c *DiscordChannel) respondInteractionEphemeral(interaction *discordgo.Interaction, content string) {
+	if c.interactionRespondFn == nil {
+		return
+	}
+	c.interactionRespondFn(interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: content,
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
+	})
 }
 
 func (c *DiscordChannel) handleMessageUpdate(s *discordgo.Session, m *discordgo.MessageUpdate) {

--- a/pkg/channels/discord_test.go
+++ b/pkg/channels/discord_test.go
@@ -482,6 +482,10 @@ func TestDiscordEnsureSlashCommandsCreatesSlashCommands(t *testing.T) {
 			if cmd.Options[1].Name != "prompt" || !cmd.Options[1].Required {
 				t.Fatalf("unexpected skill prompt option: %#v", cmd.Options[1])
 			}
+		case "theme":
+			if len(cmd.Options) != 1 || cmd.Options[0].Name != "style" || !cmd.Options[0].Required {
+				t.Fatalf("unexpected theme command options: %#v", cmd.Options)
+			}
 		default:
 			t.Fatalf("unexpected command name: %q", cmd.Name)
 		}
@@ -495,8 +499,8 @@ func TestDiscordEnsureSlashCommandsCreatesSlashCommands(t *testing.T) {
 	if err := ch.ensureSlashCommands(); err != nil {
 		t.Fatalf("ensureSlashCommands: %v", err)
 	}
-	if len(created) != 2 {
-		t.Fatalf("expected two create calls, got %d (%v)", len(created), created)
+	if len(created) != 3 {
+		t.Fatalf("expected three create calls, got %d (%v)", len(created), created)
 	}
 }
 

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -1,0 +1,140 @@
+package profile
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Valid answer themes.
+const (
+	ThemeClear  = "clear"
+	ThemeFormal = "formal"
+	ThemeBrief  = "brief"
+)
+
+// OperatorID is the profile key used by the TUI and web UI operator.
+const OperatorID = "_operator"
+
+// UserProfile stores per-user preferences.
+type UserProfile struct {
+	AnswerTheme string `json:"answer_theme"`
+	DisplayName string `json:"display_name,omitempty"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+// Store manages per-user profile files on disk.
+type Store struct {
+	dir string
+}
+
+// NewStore creates a profile store at the given directory.
+// The directory is created lazily on first write.
+func NewStore(profileDir string) *Store {
+	return &Store{dir: profileDir}
+}
+
+// Load reads a user profile from disk. Returns a zero-value profile (not an
+// error) if the file does not exist.
+func (s *Store) Load(senderID string) (*UserProfile, error) {
+	path := s.path(senderID)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &UserProfile{AnswerTheme: ThemeClear}, nil
+		}
+		return nil, fmt.Errorf("reading profile %s: %w", senderID, err)
+	}
+	var p UserProfile
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil, fmt.Errorf("parsing profile %s: %w", senderID, err)
+	}
+	if !IsValidTheme(p.AnswerTheme) {
+		p.AnswerTheme = ThemeClear
+	}
+	return &p, nil
+}
+
+// Save writes a user profile to disk atomically (temp file + rename).
+func (s *Store) Save(senderID string, p *UserProfile) error {
+	if err := os.MkdirAll(s.dir, 0o755); err != nil {
+		return fmt.Errorf("creating profile directory: %w", err)
+	}
+	p.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling profile: %w", err)
+	}
+	data = append(data, '\n')
+
+	target := s.path(senderID)
+	tmp := target + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("writing temp profile: %w", err)
+	}
+	if err := os.Rename(tmp, target); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("renaming profile: %w", err)
+	}
+	return nil
+}
+
+// AnswerTheme returns the user's answer theme, defaulting to "clear".
+func (s *Store) AnswerTheme(senderID string) string {
+	p, err := s.Load(senderID)
+	if err != nil || p == nil {
+		return ThemeClear
+	}
+	return p.AnswerTheme
+}
+
+// SetAnswerTheme validates and persists the user's answer theme.
+func (s *Store) SetAnswerTheme(senderID, displayName, theme string) error {
+	theme = strings.TrimSpace(strings.ToLower(theme))
+	if !IsValidTheme(theme) {
+		return fmt.Errorf("invalid theme %q: must be clear, formal, or brief", theme)
+	}
+	p, err := s.Load(senderID)
+	if err != nil {
+		return fmt.Errorf("loading profile for %s: %w", senderID, err)
+	}
+	p.AnswerTheme = theme
+	if displayName != "" {
+		p.DisplayName = displayName
+	}
+	return s.Save(senderID, p)
+}
+
+// IsValidTheme returns true if the theme name is recognized.
+func IsValidTheme(theme string) bool {
+	switch theme {
+	case ThemeClear, ThemeFormal, ThemeBrief:
+		return true
+	}
+	return false
+}
+
+// ThemeLabel returns a capitalized display label for the theme.
+func ThemeLabel(theme string) string {
+	switch theme {
+	case ThemeFormal:
+		return "Formal"
+	case ThemeBrief:
+		return "Brief"
+	default:
+		return "Clear"
+	}
+}
+
+func (s *Store) path(senderID string) string {
+	safe := strings.Map(func(r rune) rune {
+		if r == '/' || r == '\\' || r == '\x00' {
+			return '_'
+		}
+		return r
+	}, senderID)
+	return filepath.Join(s.dir, safe+".json")
+}

--- a/pkg/profile/profile_test.go
+++ b/pkg/profile/profile_test.go
@@ -1,0 +1,113 @@
+package profile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadMissing(t *testing.T) {
+	store := NewStore(t.TempDir())
+	p, err := store.Load("nonexistent")
+	if err != nil {
+		t.Fatalf("expected no error for missing profile, got %v", err)
+	}
+	if p.AnswerTheme != ThemeClear {
+		t.Fatalf("expected clear default, got %q", p.AnswerTheme)
+	}
+}
+
+func TestSaveAndLoad(t *testing.T) {
+	store := NewStore(t.TempDir())
+	err := store.SetAnswerTheme("user123", "Alice", ThemeBrief)
+	if err != nil {
+		t.Fatalf("SetAnswerTheme: %v", err)
+	}
+
+	p, err := store.Load("user123")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if p.AnswerTheme != ThemeBrief {
+		t.Fatalf("expected brief, got %q", p.AnswerTheme)
+	}
+	if p.DisplayName != "Alice" {
+		t.Fatalf("expected Alice, got %q", p.DisplayName)
+	}
+	if p.UpdatedAt == "" {
+		t.Fatal("expected UpdatedAt to be set")
+	}
+}
+
+func TestAnswerThemeDefault(t *testing.T) {
+	store := NewStore(t.TempDir())
+	theme := store.AnswerTheme("nobody")
+	if theme != ThemeClear {
+		t.Fatalf("expected clear, got %q", theme)
+	}
+}
+
+func TestInvalidTheme(t *testing.T) {
+	store := NewStore(t.TempDir())
+	err := store.SetAnswerTheme("user1", "", "invalid")
+	if err == nil {
+		t.Fatal("expected error for invalid theme")
+	}
+}
+
+func TestOverwrite(t *testing.T) {
+	store := NewStore(t.TempDir())
+	store.SetAnswerTheme("user1", "Bob", ThemeFormal)
+	store.SetAnswerTheme("user1", "", ThemeBrief)
+
+	p, _ := store.Load("user1")
+	if p.AnswerTheme != ThemeBrief {
+		t.Fatalf("expected brief after overwrite, got %q", p.AnswerTheme)
+	}
+	if p.DisplayName != "Bob" {
+		t.Fatalf("expected Bob preserved, got %q", p.DisplayName)
+	}
+}
+
+func TestAtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+	store.SetAnswerTheme("user1", "Test", ThemeClear)
+
+	// No .tmp files should remain
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".tmp" {
+			t.Fatalf("temp file not cleaned up: %s", e.Name())
+		}
+	}
+}
+
+func TestPathSanitization(t *testing.T) {
+	store := NewStore(t.TempDir())
+	err := store.SetAnswerTheme("../../etc/passwd", "hacker", ThemeClear)
+	if err != nil {
+		t.Fatalf("SetAnswerTheme: %v", err)
+	}
+	// Should create a safe filename, not traverse directories
+	p, err := store.Load("../../etc/passwd")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if p.DisplayName != "hacker" {
+		t.Fatalf("expected hacker, got %q", p.DisplayName)
+	}
+}
+
+func TestIsValidTheme(t *testing.T) {
+	for _, theme := range []string{"clear", "formal", "brief"} {
+		if !IsValidTheme(theme) {
+			t.Fatalf("expected %q to be valid", theme)
+		}
+	}
+	for _, theme := range []string{"", "invalid", "CLEAR", "Clear"} {
+		if IsValidTheme(theme) {
+			t.Fatalf("expected %q to be invalid", theme)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds per-user profile system that persists answer theme preferences to disk
- Users set their theme via Discord `/theme` slash command — ephemeral, instant, follows them across all channels
- Theme injected into system prompt on every turn so the LLM adapts its response style
- Three themes: **Clear** (default), **Formal**, **Brief** — defined in AGENTS.md (already on main)

## How it works

A user types `/theme brief` in any Discord channel. An ephemeral confirmation appears (only they see it). From that point, every response to that user follows the Brief style (3-5 sentences, no hedging, decision-ready). The preference persists across gateway restarts, channels, and routed workspaces.

## Architecture

| Component | File | What it does |
|-----------|------|-------------|
| Profile store | `pkg/profile/profile.go` | JSON files at `~/.picoclaw/profiles/<channel>:<id>.json`, atomic writes, graceful defaults |
| Prompt injection | `pkg/agent/context.go` | `SetSenderContext` → Active User section in system prompt after AGENTS.md |
| Turn wiring | `pkg/agent/loop.go` | `ThemeResolver` interface, profile lookup before `BuildMessages`, context cleared per-turn |
| `/theme` command | `pkg/channels/discord.go` | Slash command with 3 choices, ephemeral response, allowlist enforced |
| Gateway startup | `cmd/picoclaw/main.go` | Single shared store wired to main loop, routed pool, and Discord handler |

## Safety (addressed in Codex gpt-5.4 xhigh review)

- Sender context cleared at start of every turn — prevents theme leaking between users
- Profile keys namespaced by platform (`discord:123456`) — prevents cross-platform ID collision
- Username sanitized before prompt injection — 64 char max, no control chars, single line
- `/theme` respects allowlist — unauthorized Discord users can't create profile files
- Theme validated on both read and write — invalid values fall back to `clear`, never reach the prompt
- `SetAnswerTheme` returns load errors instead of silently destroying corrupt profiles
- Formal theme says "cite when available; never invent sources" — prevents fabrication pressure

## Test plan

- [x] `go build ./...` — compiles clean
- [x] `go test ./pkg/profile/ -v` — 8 unit tests pass
- [x] `go test ./pkg/agent/ ./pkg/channels/` — all pass including updated slash command test
- [ ] Deploy to data3, type `/theme brief` in Discord → verify ephemeral response
- [ ] Send a question → verify Brief-style response (3-5 sentences)
- [ ] Type `/theme clear` → send same question → verify Clear-style response (prose with subheadings)
- [ ] Verify `~/.picoclaw/profiles/discord:<id>.json` exists on data3
- [ ] Verify theme persists after gateway restart
- [ ] Verify unauthorized user gets rejected on `/theme`

## Not in this PR (future work)

- Web UI theme selector (Settings page dropdown)
- TUI theme selector (tab_settings enum row)
- Additional per-user preferences (citation style, language, expertise level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)