### PR TITLE
feat: Codex GPT image generation in chat (v0.3.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ The most natural way to use sciClaw is through **Telegram** or **Discord**. You 
 You:      "Find recent papers on TDP-43 proteinopathy in ALS"
 sciClaw:  [searches PubMed, returns 47 papers with citations, saves to workspace]
 
+You:      "Image, generate a schematic of TDP-43 condensate formation under stress"
+sciClaw:  [generates a figure via OpenAI image gen, saves it, attaches the PNG in chat]
+
 You:      "Draft a methods section using the attached protocol"
 sciClaw:  [produces a Word doc with tracked changes you review in Microsoft Word]
 ```
@@ -198,6 +201,7 @@ Bundled skills include:
 ### Authoring & Visualization
 - **quarto-authoring** — Loop-driven `.qmd` authoring and rendering
 - **pandoc-docx** — Clean `.docx` manuscript generation from Markdown with NIH template auto-apply
+- **Chat image generation** — On OpenAI Codex/OAuth + GPT-5.x, ask “Image, generate …” to create figures via the Responses `image_generation` tool; PNGs are saved under `artifacts/generated/` and attached in Discord/Telegram
 - **imagemagick** — Reproducible image preprocessing (resize, crop, convert, DPI normalization) via `magick`
 - **beautiful-mermaid** — Publication-grade Mermaid diagrams
 - **explainer-site** — Technical, single-page "How X Works" explainer site generation

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -250,17 +250,39 @@
           <div class="track">
             <strong>Stable channel</strong>
             <code>brew install sciclaw</code>
-            <div class="meta">Production track. Current public stable: <strong>v0.3.4</strong>.</div>
+            <div class="meta">Production track. Current public stable: <strong>v0.3.5</strong>.</div>
           </div>
           <div class="track">
             <strong>Dev channel</strong>
             <code>brew install sciclaw-dev</code>
-            <div class="meta">Preview track for upcoming features and fixes. Current preview: <strong>v0.3.2-dev.1</strong>.</div>
+            <div class="meta">Preview track for upcoming features and fixes. Current preview: <strong>v0.3.5-dev.1</strong>.</div>
           </div>
         </div>
       </section>
 
       <section class="timeline">
+
+        <!-- v0.3.5 -->
+        <article class="item">
+          <div class="item-head">
+            <div class="tagline">
+              <span class="tag stable">stable</span>
+              <span class="rel">v0.3.5</span>
+            </div>
+            <span class="date">July 8, 2026</span>
+          </div>
+          <ul>
+            <li><strong>Chat image generation.</strong> On the OpenAI Codex/OAuth Responses path, sciClaw exposes the hosted <code>image_generation</code> tool. Ask in Discord or Telegram to generate an illustration and get a PNG attachment back.</li>
+            <li><strong>Workspace artifacts.</strong> Generated images are saved under <code>workspace/artifacts/generated/</code> and delivered through the existing outbound attachment path.</li>
+            <li><strong>Prompt catalog awareness.</strong> When Codex is the active provider, the system prompt lists the provider-hosted image tool so the model knows it is available alongside local tools and skills.</li>
+            <li><strong>Cron startup hardening.</strong> An empty <code>cron/jobs.json</code> is treated as an empty store instead of failing cron startup with <code>unexpected end of JSON input</code>.</li>
+            <li><strong>Toolchain.</strong> Pinned <code>docx-review</code> 1.5.1 and updated CI actions for Node 24.</li>
+          </ul>
+          <div class="links">
+            <a href="https://github.com/drpedapati/sciclaw/releases/tag/v0.3.5" target="_blank" rel="noopener noreferrer">Release</a>
+            <a href="https://github.com/drpedapati/sciclaw/compare/v0.3.4...v0.3.5" target="_blank" rel="noopener noreferrer">Compare</a>
+          </div>
+        </article>
 
         <!-- v0.3.4 -->
         <article class="item">

--- a/docs/issues/gpt55-image-generation-rfc.md
+++ b/docs/issues/gpt55-image-generation-rfc.md
@@ -2,7 +2,17 @@
 
 ## Status
 
-Research / planning. No runtime implementation in this PR.
+Implemented MVP on this branch (Codex/Responses hosted `image_generation` tool).
+
+What shipped:
+- Codex tool translation appends `{type: "image_generation"}` whenever function tools are present
+- `parseCodexResponse` decodes `image_generation_call` base64 into `LLMResponse.Media`
+- Agent persists PNGs under `workspace/artifacts/generated/` and attaches them on outbound chat messages
+
+Remaining gaps:
+- API-key Chat Completions path still has no image generation
+- Multi-turn image edit / inbound photo edit not wired
+- Enable/disable config flag and cost controls still open
 
 ## Goal
 

--- a/docs/issues/gpt55-image-generation-rfc.md
+++ b/docs/issues/gpt55-image-generation-rfc.md
@@ -1,0 +1,292 @@
+# RFC: GPT Image Generation in sciClaw Chat
+
+## Status
+
+Research / planning. No runtime implementation in this PR.
+
+## Goal
+
+Let a user say something like:
+
+> Image, generate a schematic of TDP-43 condensate formation under stress
+
+…and have sciClaw generate an image, save it in the workspace, and send it back on Telegram/Discord/email as an attachment.
+
+This RFC covers:
+
+1. How OpenAI’s current GPT image APIs actually work (including GPT-5.5)
+2. How sciClaw’s AI / tool layer is structured today
+3. Why a naive “just enable image gen on the model” approach will fail
+4. Conflicting image-related skills and how to disambiguate them
+5. A phased, feasible implementation plan
+
+## Research Summary: How To Call It
+
+OpenAI exposes **two** official routes. They are easy to conflate.
+
+### Route A — Image API (direct)
+
+Best when the image is the product of the call.
+
+```http
+POST https://api.openai.com/v1/images/generations
+Authorization: Bearer $OPENAI_API_KEY
+Content-Type: application/json
+
+{
+  "model": "gpt-image-2",
+  "prompt": "A schematic of TDP-43 condensate formation under stress",
+  "size": "1024x1024",
+  "quality": "high"
+}
+```
+
+Response includes base64 (`b64_json`) image bytes. Edits use `/v1/images/edits`.
+
+Current GPT Image model family (as of OpenAI docs, 2026):
+
+| Model | Role |
+| --- | --- |
+| `gpt-image-2` | Latest / recommended for new work |
+| `gpt-image-1.5` | Prior generation |
+| `gpt-image-1` | Original GPT Image |
+| `gpt-image-1-mini` | Cheaper / faster |
+
+**Important:** `gpt-image-2` is **not** a valid `model` for the Responses API chat turn. It is the image model behind generation.
+
+Org verification may be required in the OpenAI developer console before GPT Image models work.
+
+### Route B — Responses API `image_generation` tool (conversational)
+
+Best when image generation is one step inside an agent turn. Official GPT-5.5 example:
+
+```js
+const response = await openai.responses.create({
+  model: "gpt-5.5",
+  input: "Generate an image of gray tabby cat hugging an otter with an orange scarf",
+  tools: [{ type: "image_generation" }],
+});
+
+const imageData = response.output
+  .filter((o) => o.type === "image_generation_call")
+  .map((o) => o.result); // base64
+```
+
+Key details:
+
+- Mainline model is `gpt-5.5` / `gpt-5.2` / etc.
+- Hosted tool type is `image_generation` (not a sciClaw function tool)
+- Optional `tool_choice: { type: "image_generation" }` forces the call
+- Optional tool params: `action` (`auto` | `generate` | `edit`), `size`, `quality`, `output_format`, and an image-model override
+- Output item type is `image_generation_call` with base64 in `result`
+- Multi-turn edit works by keeping prior `image_generation_call` items (or IDs) in context
+
+Sources:
+
+- https://developers.openai.com/api/docs/guides/image-generation
+- https://developers.openai.com/api/docs/guides/tools-image-generation
+- https://developers.openai.com/api/docs/models/gpt-image-2
+
+## Current sciClaw Architecture (relevant bits)
+
+### Provider split
+
+`CreateProvider` in `pkg/providers/http_provider.go`:
+
+| Auth / config | Provider | Wire protocol |
+| --- | --- | --- |
+| OpenAI API key | `HTTPProvider` | Chat Completions `POST /chat/completions` |
+| OpenAI OAuth / stored token | `CodexProvider` | Responses streaming via `chatgpt.com/backend-api/codex` |
+| Anthropic | Claude providers | Anthropic Messages / agent bridge |
+| PHI mode | Ollama / local | Local OpenAI-compatible |
+
+Implications:
+
+1. **API-key OpenAI path cannot use the hosted `image_generation` tool today** — it never calls `/v1/responses`.
+2. **OAuth Codex path already speaks Responses**, but `buildCodexParams` / `translateToolsForCodex` only emit **function** tools, and `parseCodexResponse` only handles `message` + `function_call`. It **drops** `image_generation_call` output items.
+3. Community reports suggest Codex OAuth tokens often **cannot** call `/v1/images/*` directly; those endpoints expect a normal API key. Treat OAuth image support as unverified until smoke-tested.
+
+### Agent tool loop
+
+`pkg/agent/loop.go` builds a `tools.ToolRegistry` of **local** tools (`read_file`, `exec`, `message`, PubMed, review tools, etc.). The model proposes function calls; sciClaw executes them and feeds results back.
+
+This is the opposite of OpenAI’s hosted `image_generation` tool, where OpenAI executes the tool server-side and returns image bytes in the response.
+
+### Delivery already exists
+
+Channels already send files:
+
+- Telegram: photo/document via `OutboundAttachment`
+- Discord: file upload via `OutboundAttachment`
+- Email: base64 attachments
+
+The `message` tool already accepts `attachments: [{ path, filename }]`.
+
+So once an image exists on disk under the workspace, delivery is mostly solved.
+
+### Skills are prompt packs, not executors
+
+`pkg/skills/loader.go` injects `SKILL.md` text into context. Skills do **not** register Go tools. A skill alone cannot call OpenAI image APIs.
+
+## Conflicting “Image” Surfaces
+
+These are not the same product. The agent will thrash without explicit routing rules.
+
+| Surface | What it actually does | When to use |
+| --- | --- | --- |
+| `skills/imagemagick` | Deterministic `magick` preprocess (resize/crop/DPI) | Existing scientific figures |
+| `skills/beautiful-mermaid` | Diagram source → SVG | Architecture / methods diagrams |
+| `skills/explainer-site` | HTML explainer pages (often with Mermaid) | Educational sites |
+| Cursor Higgsfield / GenerateImage skills | IDE-side image/video generation | Cursor agent sessions only — **not** sciClaw runtime |
+| Proposed `generate_image` tool | OpenAI GPT Image → workspace file | “Image, generate …” chat requests |
+| Future Responses `image_generation` | Hosted tool on GPT-5.5 turns | Multi-turn edit inside OpenAI Responses path |
+
+**Decision for v1:** keep ImageMagick / Mermaid / explainer skills unchanged. Add a **typed Go tool** for generative images, plus a thin skill that teaches the model when to call it vs preprocess/diagram skills.
+
+## Feasibility Verdict
+
+| Approach | Feasible now? | Notes |
+| --- | --- | --- |
+| **A. Local `generate_image` tool → Image API (`gpt-image-2`)** | **Yes — recommended MVP** | Works with API key; fits existing tool loop; saves file; `message` attaches it. Provider-agnostic for Anthropic users who still have an OpenAI key for images. |
+| **B. Enable Responses hosted `image_generation` on Codex** | Medium / later | Needs tool translation, response parsing, disk write, and Codex backend capability verification. |
+| **C. Migrate `HTTPProvider` to Responses + hosted tool** | Large | Touches every OpenAI API-key chat turn; high regression risk. |
+| **D. Skill-only (no Go tool)** | No | Skills cannot call APIs; model would invent shell/`curl` hacks. |
+| **E. Force model to shell out to `curl`** | No | Fragile, secret leakage risk, poor UX. |
+
+**Recommended path: A first, B second.**
+
+## Proposed UX
+
+Natural language (no slash required for MVP):
+
+- “Image, generate a lab schematic of …”
+- “Generate an image of …”
+- “Make a figure illustration of …”
+
+Optional later Discord surface (fits existing `/skill` pattern):
+
+- `/skill name:image-gen prompt:…`
+
+Agent behavior:
+
+1. Call `generate_image` with the user prompt (and optional size/quality).
+2. Tool writes `workspace/artifacts/generated/<timestamp>-<slug>.png` (or configured dir).
+3. Tool returns path + revised prompt metadata.
+4. Agent calls `message` with that path as an attachment (and a short caption).
+
+Routing rules to encode in skill + tool description:
+
+- Generative / illustrative / “make an image” → `generate_image`
+- Resize / DPI / convert existing asset → `imagemagick`
+- Flowchart / architecture diagram → `beautiful-mermaid`
+- Do not invent fake citations or photorealistic “experimental results” presented as real data
+
+## Implementation Plan
+
+### Phase 0 — Smoke tests (before coding much)
+
+1. With a verified OpenAI **API key**, call `/v1/images/generations` with `model: "gpt-image-2"`.
+2. With the same key, call `/v1/responses` with `model: "gpt-5.5"` and `tools: [{type:"image_generation"}]`.
+3. With sciClaw **OAuth / Codex** credentials, attempt both; record which fail.
+4. Confirm org verification status if 403/verification errors appear.
+
+Exit criteria: know which auth modes can generate images in this account.
+
+### Phase 1 — MVP local tool (shippable)
+
+Files (expected):
+
+- `pkg/tools/generate_image.go` (+ tests)
+- Register in `pkg/agent/loop.go` `createToolRegistry`
+- `skills/image-gen/SKILL.md` (routing + provenance notes)
+- AGENTS.md baseline skill bullet
+- Config knobs (optional): enable flag, default model `gpt-image-2`, default size/quality, output dir
+
+Tool sketch:
+
+```text
+name: generate_image
+params:
+  prompt: string (required)
+  size?: "1024x1024" | "1024x1536" | "1536x1024" | "auto"
+  quality?: "low" | "medium" | "high"
+  filename?: string
+behavior:
+  - resolve OpenAI API key from config/env (not Codex OAuth by default)
+  - POST /v1/images/generations
+  - decode b64 → workspace file
+  - return { path, model, size, revised_prompt? }
+```
+
+Auth policy for MVP:
+
+- Require OpenAI API key (`config.providers.openai.api_key` or env).
+- If user is on Anthropic for chat but has an OpenAI key configured, still allow image gen.
+- If only OAuth Codex creds exist, return a clear error: “Image generation needs an OpenAI API key (OAuth/Codex path not supported yet).”
+
+Tests:
+
+- Mock HTTP server for generations response
+- Workspace path restriction
+- Missing-key error
+- Attachment round-trip via `message` tool args (unit-level)
+
+### Phase 2 — Chat intent reliability
+
+- Strengthen tool description + `image-gen` skill so “Image, generate …” reliably selects the tool
+- Optional lightweight intent hint in context builder when message matches `/^\s*image[,:]/i` (keep tiny; prefer model+tool over brittle regex)
+- Doctor check: warn if image skill enabled but no OpenAI API key
+
+### Phase 3 — Responses / GPT-5.5 hosted tool (optional)
+
+Only after Phase 0 proves Codex or API-key Responses works:
+
+1. Extend `translateToolsForCodex` (or a dedicated Responses OpenAI provider) to append `{type: "image_generation", ...}`.
+2. Extend `parseCodexResponse` to handle `image_generation_call`, write bytes to disk, and surface a synthetic local tool result or attachment hint.
+3. Decide whether hosted tool **replaces** or **supplements** the local `generate_image` tool (recommend: keep local tool as the portable path; hosted tool as OpenAI-only enhancement for multi-turn edit).
+
+### Phase 4 — Edits / references
+
+- Accept inbound chat photos as edit inputs (`/v1/images/edits` or Responses `action: "edit"`)
+- Mask support later if needed
+
+## Risks & Open Questions
+
+1. **OAuth vs API key:** Can Codex backend host `image_generation` for sciClaw OAuth users? Unknown until smoke-tested.
+2. **Cost / abuse:** Image gen is expensive; need enable flag + maybe per-workspace allowlist.
+3. **Scientific integrity:** Generated illustrations must not be presented as real experimental data. Skill copy must say so.
+4. **Vendor SDK age:** Vendored `openai-go/v3` documents older GPT Image models in some comments; Image API may still accept `gpt-image-2` via raw HTTP even if SDK enums lag. Prefer thin HTTP client in the tool (like `WeatherForecastTool`) or bump vendor.
+5. **PHI mode:** Local models cannot call OpenAI image APIs; tool must no-op/error clearly in PHI mode.
+6. **Cursor skill confusion:** Higgsfield / GenerateImage skills live in the IDE, not sciClaw. Document that they are out of scope for runtime chat.
+
+## Non-Goals (this effort)
+
+- Replacing ImageMagick preprocessing
+- Building a general media studio UI
+- Migrating all OpenAI traffic to Responses in one PR
+- Supporting Midjourney / Flux / Higgsfield as sciClaw backends
+
+## Suggested PR Sequence (after this plan PR)
+
+1. `feat: add generate_image tool (gpt-image-2 Image API)`
+2. `feat: image-gen skill + AGENTS routing`
+3. `feat: doctor/config for image generation credentials`
+4. (optional) `feat: Responses image_generation on OpenAI path`
+
+## Acceptance Criteria for the Feature (not this plan PR)
+
+- [ ] User can ask in Telegram/Discord to generate an image and receive a photo/file back
+- [ ] Artifact is saved under the workspace with a stable path
+- [ ] ImageMagick / Mermaid requests still route correctly
+- [ ] Missing API key / PHI mode produce actionable errors
+- [ ] Unit tests cover the tool without live OpenAI calls
+
+## Appendix: Why Not Only Responses + GPT-5.5?
+
+GPT-5.5 + `tools: [{type:"image_generation"}]` is the cleanest **OpenAI-native** agent story. sciClaw’s difficulty is not the API shape — it is that:
+
+1. Most of the tool ecosystem is **local function tools** on a Chat Completions-shaped loop.
+2. The Responses-capable path (`CodexProvider`) does not yet understand image tool outputs.
+3. Many installs will want image gen while chatting on Anthropic.
+
+A local `generate_image` tool sidesteps all three for MVP, while leaving the door open to hosted Responses image gen later.

--- a/docs/v0.3.5-announcement.md
+++ b/docs/v0.3.5-announcement.md
@@ -1,0 +1,23 @@
+# sciClaw v0.3.5 Announcement
+
+## Tweet
+
+sciClaw v0.3.5 is out.
+
+In Discord/Telegram you can now say “Image, generate …” and get a real figure back — GPT image gen over OpenAI Responses, saved to your workspace and attached in chat.
+
+Also: empty cron jobs.json no longer blocks gateway startup.
+
+brew update && brew upgrade sciclaw
+sciclaw service refresh
+
+https://github.com/drpedapati/sciclaw/releases/tag/v0.3.5
+
+---
+
+## Short notes
+
+- OpenAI Codex/OAuth path exposes the hosted `image_generation` tool on GPT-5.x turns
+- Generated PNGs land in `workspace/artifacts/generated/` and ship as chat attachments
+- Prompt catalog notes the provider-hosted tool so the model knows it is available
+- Empty `cron/jobs.json` is treated as an empty store (gateway still starts Discord/email)

--- a/pkg/agent/artifacts.go
+++ b/pkg/agent/artifacts.go
@@ -1,12 +1,62 @@
 package agent
 
 import (
+	"fmt"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"github.com/sipeed/picoclaw/pkg/bus"
+	"github.com/sipeed/picoclaw/pkg/logger"
+	"github.com/sipeed/picoclaw/pkg/providers"
 	"github.com/sipeed/picoclaw/pkg/session"
 )
+
+func (al *AgentLoop) persistProviderMedia(media []providers.MediaAttachment) []bus.OutboundAttachment {
+	if len(media) == 0 {
+		return nil
+	}
+	outDir := filepath.Join(al.workspace, "artifacts", "generated")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		logger.WarnCF("agent", "Failed to create generated media directory", map[string]interface{}{
+			"dir":   outDir,
+			"error": err.Error(),
+		})
+		return nil
+	}
+
+	attachments := make([]bus.OutboundAttachment, 0, len(media))
+	for i, item := range media {
+		path := strings.TrimSpace(item.Path)
+		filename := strings.TrimSpace(item.Filename)
+		if filename == "" {
+			filename = fmt.Sprintf("generated-%s-%d.png", time.Now().UTC().Format("20060102-150405"), i+1)
+		}
+		filename = filepath.Base(filename)
+
+		if path == "" {
+			if len(item.Data) == 0 {
+				continue
+			}
+			path = filepath.Join(outDir, filename)
+			if err := os.WriteFile(path, item.Data, 0o644); err != nil {
+				logger.WarnCF("agent", "Failed to persist generated media", map[string]interface{}{
+					"path":  path,
+					"error": err.Error(),
+				})
+				continue
+			}
+		}
+
+		attachments = append(attachments, bus.OutboundAttachment{
+			Path:     path,
+			Filename: filename,
+		})
+	}
+	return attachments
+}
 
 func (al *AgentLoop) registerInboundArtifacts(sessionKey string, media []string) {
 	if strings.TrimSpace(sessionKey) == "" || len(media) == 0 {

--- a/pkg/agent/artifacts_media_test.go
+++ b/pkg/agent/artifacts_media_test.go
@@ -1,0 +1,42 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sipeed/picoclaw/pkg/bus"
+	"github.com/sipeed/picoclaw/pkg/config"
+	"github.com/sipeed/picoclaw/pkg/providers"
+)
+
+func TestPersistProviderMedia_WritesWorkspacePNG(t *testing.T) {
+	workspace := t.TempDir()
+	cfg := config.DefaultConfig()
+	cfg.Agents.Defaults.Workspace = workspace
+	al := NewAgentLoop(cfg, bus.NewMessageBus(), &mockProvider{})
+
+	png := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}
+	got := al.persistProviderMedia([]providers.MediaAttachment{{
+		Filename: "cube.png",
+		MIME:     "image/png",
+		Data:     png,
+	}})
+	if len(got) != 1 {
+		t.Fatalf("attachments=%d want 1", len(got))
+	}
+	if got[0].Filename != "cube.png" {
+		t.Fatalf("filename=%q want cube.png", got[0].Filename)
+	}
+	wantPath := filepath.Join(workspace, "artifacts", "generated", "cube.png")
+	if got[0].Path != wantPath {
+		t.Fatalf("path=%q want %q", got[0].Path, wantPath)
+	}
+	data, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("read generated file: %v", err)
+	}
+	if string(data) != string(png) {
+		t.Fatalf("file bytes mismatch")
+	}
+}

--- a/pkg/agent/context.go
+++ b/pkg/agent/context.go
@@ -22,6 +22,10 @@ type ContextBuilder struct {
 	memory                     *MemoryStore
 	tools                      *tools.ToolRegistry // Direct reference to tool registry
 	includePromptToolSummaries bool
+	// hostedToolNotes are provider-hosted capabilities that are not local Go
+	// tools (for example Codex Responses image_generation). They still need to
+	// appear in the system prompt so the model knows they exist.
+	hostedToolNotes []string
 
 	// Per-turn sender context (set before each BuildMessages call)
 	senderID    string
@@ -138,6 +142,19 @@ func (cb *ContextBuilder) SetToolsRegistry(registry *tools.ToolRegistry) {
 	cb.tools = registry
 }
 
+// SetHostedToolNotes records provider-hosted tools that are not in the local
+// ToolRegistry but are available on the current provider path.
+func (cb *ContextBuilder) SetHostedToolNotes(notes ...string) {
+	cb.hostedToolNotes = nil
+	for _, note := range notes {
+		note = strings.TrimSpace(note)
+		if note == "" {
+			continue
+		}
+		cb.hostedToolNotes = append(cb.hostedToolNotes, note)
+	}
+}
+
 // SetIncludePromptToolSummaries controls whether human-readable tool summaries
 // are embedded into the system prompt. When the provider already receives native
 // tool schemas, duplicating the tool list in prose wastes prompt tokens.
@@ -197,25 +214,34 @@ Your workspace is at: %s
 }
 
 func (cb *ContextBuilder) buildToolsSection() string {
-	if !cb.includePromptToolSummaries {
-		return ""
+	localSummaries := []string(nil)
+	if cb.includePromptToolSummaries && cb.tools != nil {
+		localSummaries = cb.tools.GetSummaries()
 	}
-	if cb.tools == nil {
-		return ""
-	}
-
-	summaries := cb.tools.GetSummaries()
-	if len(summaries) == 0 {
+	if len(localSummaries) == 0 && len(cb.hostedToolNotes) == 0 {
 		return ""
 	}
 
 	var sb strings.Builder
 	sb.WriteString("## Available Tools\n\n")
 	sb.WriteString("**CRITICAL**: You MUST use tools to perform actions. Do NOT pretend to execute commands or schedule tasks.\n\n")
-	sb.WriteString("You have access to the following tools:\n\n")
-	for _, s := range summaries {
-		sb.WriteString(s)
-		sb.WriteString("\n")
+	if len(localSummaries) > 0 {
+		sb.WriteString("You have access to the following tools:\n\n")
+		for _, s := range localSummaries {
+			sb.WriteString(s)
+			sb.WriteString("\n")
+		}
+	}
+	if len(cb.hostedToolNotes) > 0 {
+		if len(localSummaries) > 0 {
+			sb.WriteString("\n")
+		}
+		sb.WriteString("### Provider-hosted tools\n\n")
+		for _, note := range cb.hostedToolNotes {
+			sb.WriteString("- ")
+			sb.WriteString(note)
+			sb.WriteString("\n")
+		}
 	}
 
 	return sb.String()

--- a/pkg/agent/context_test.go
+++ b/pkg/agent/context_test.go
@@ -9,6 +9,24 @@ import (
 	"github.com/sipeed/picoclaw/pkg/tools"
 )
 
+func TestBuildSystemPromptIncludesHostedToolNotes(t *testing.T) {
+	workspace := t.TempDir()
+	cb := NewContextBuilder(workspace)
+	cb.SetIncludePromptToolSummaries(false)
+	cb.SetHostedToolNotes("`image_generation` (OpenAI Responses) — generate images in chat")
+
+	prompt := cb.BuildSystemPrompt()
+	if !strings.Contains(prompt, "## Available Tools") {
+		t.Fatalf("expected Available Tools section for hosted notes")
+	}
+	if !strings.Contains(prompt, "### Provider-hosted tools") {
+		t.Fatalf("expected Provider-hosted tools subsection")
+	}
+	if !strings.Contains(prompt, "`image_generation` (OpenAI Responses)") {
+		t.Fatalf("expected image_generation hosted note in prompt")
+	}
+}
+
 func TestBuildSystemPromptUsesSciClawIdentity(t *testing.T) {
 	workspace := t.TempDir()
 	cb := NewContextBuilder(workspace)

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -365,6 +365,13 @@ func NewAgentLoopWithOptions(cfg *config.Config, msgBus *bus.MessageBus, provide
 	contextBuilder := NewContextBuilder(workspace, cfg.SharedWorkspacePath())
 	contextBuilder.SetToolsRegistry(toolsRegistry)
 	contextBuilder.SetIncludePromptToolSummaries(false)
+	// Hosted Responses tools are appended by CodexProvider, not the local
+	// ToolRegistry. Surface them in the prompt catalog so the model knows.
+	if _, ok := provider.(*providers.CodexProvider); ok {
+		contextBuilder.SetHostedToolNotes(
+			"`image_generation` (OpenAI Responses) — when the user asks to generate or illustrate an image, use this hosted tool. Prefer `beautiful-mermaid` for diagrams and ImageMagick for editing existing files. Do not present generated images as real experimental data.",
+		)
+	}
 	contextBuilder.SetVersion(Version)
 
 	var hookDispatcher *hooks.Dispatcher

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -147,6 +147,7 @@ func (e *incompleteTurnError) UserMessage() string {
 
 type llmIterationResult struct {
 	FinalContent string
+	Media        []bus.OutboundAttachment
 	Iterations   int
 	Usage        turnUsage
 	TurnErr      error
@@ -524,7 +525,7 @@ func (al *AgentLoop) Stop() {
 // HandleInbound processes one inbound message and publishes any response.
 // It is used both by the default bus consumer loop and routed dispatchers.
 func (al *AgentLoop) HandleInbound(ctx context.Context, msg bus.InboundMessage) {
-	response, err := al.processMessage(ctx, msg)
+	response, media, err := al.processMessageWithMedia(ctx, msg, nil)
 	if err != nil && strings.TrimSpace(response) == "" {
 		if uerr, ok := err.(userVisibleError); ok && strings.TrimSpace(uerr.UserMessage()) != "" {
 			response = uerr.UserMessage()
@@ -543,11 +544,11 @@ func (al *AgentLoop) HandleInbound(ctx context.Context, msg bus.InboundMessage) 
 			})
 	}
 
-	al.publishFinalResponse(ctx, msg, response)
+	al.publishFinalResponseWithMedia(ctx, msg, response, media)
 }
 
 func (al *AgentLoop) RunJob(ctx context.Context, msg bus.InboundMessage, onProgress func(phase, detail string)) (string, error) {
-	response, err := al.processMessageWithProgress(ctx, msg, onProgress)
+	response, media, err := al.processMessageWithMedia(ctx, msg, onProgress)
 	if err != nil && strings.TrimSpace(response) == "" {
 		if uerr, ok := err.(userVisibleError); ok && strings.TrimSpace(uerr.UserMessage()) != "" {
 			response = uerr.UserMessage()
@@ -555,12 +556,16 @@ func (al *AgentLoop) RunJob(ctx context.Context, msg bus.InboundMessage, onProgr
 			response = fmt.Sprintf("Error processing message: %v", err)
 		}
 	}
-	al.publishFinalResponse(ctx, msg, response)
+	al.publishFinalResponseWithMedia(ctx, msg, response, media)
 	return response, err
 }
 
 func (al *AgentLoop) publishFinalResponse(ctx context.Context, msg bus.InboundMessage, response string) {
-	if response == "" {
+	al.publishFinalResponseWithMedia(ctx, msg, response, nil)
+}
+
+func (al *AgentLoop) publishFinalResponseWithMedia(ctx context.Context, msg bus.InboundMessage, response string, media []bus.OutboundAttachment) {
+	if response == "" && len(media) == 0 {
 		if msg.Channel != "system" {
 			logger.InfoCF("agent", "No outbound response generated",
 				map[string]interface{}{
@@ -583,10 +588,15 @@ func (al *AgentLoop) publishFinalResponse(ctx context.Context, msg bus.InboundMe
 	}
 
 	if !alreadySent {
+		content := response
+		if strings.TrimSpace(content) == "" && len(media) > 0 {
+			content = "Generated image."
+		}
 		al.bus.PublishOutbound(ctx, bus.OutboundMessage{
-			Channel: msg.Channel,
-			ChatID:  msg.ChatID,
-			Content: response,
+			Channel:     msg.Channel,
+			ChatID:      msg.ChatID,
+			Content:     content,
+			Attachments: media,
 		})
 	} else {
 		logger.InfoCF("agent", "Suppressing outbound response because message tool already sent content",
@@ -596,6 +606,7 @@ func (al *AgentLoop) publishFinalResponse(ctx context.Context, msg bus.InboundMe
 				"sender_id":        msg.SenderID,
 				"session_key":      msg.SessionKey,
 				"response_preview": utils.Truncate(response, 120),
+				"media_count":      len(media),
 			})
 	}
 }
@@ -658,10 +669,16 @@ func (al *AgentLoop) ProcessHeartbeat(ctx context.Context, content, channel, cha
 }
 
 func (al *AgentLoop) processMessage(ctx context.Context, msg bus.InboundMessage) (string, error) {
-	return al.processMessageWithProgress(ctx, msg, nil)
+	response, _, err := al.processMessageWithMedia(ctx, msg, nil)
+	return response, err
 }
 
 func (al *AgentLoop) processMessageWithProgress(ctx context.Context, msg bus.InboundMessage, onProgress func(phase, detail string)) (string, error) {
+	response, _, err := al.processMessageWithMedia(ctx, msg, onProgress)
+	return response, err
+}
+
+func (al *AgentLoop) processMessageWithMedia(ctx context.Context, msg bus.InboundMessage, onProgress func(phase, detail string)) (string, []bus.OutboundAttachment, error) {
 	// Add message preview to log (show full content for error messages)
 	var logContent string
 	if strings.Contains(msg.Content, "Error:") || strings.Contains(msg.Content, "error") {
@@ -679,7 +696,8 @@ func (al *AgentLoop) processMessageWithProgress(ctx context.Context, msg bus.Inb
 
 	// Route system messages to processSystemMessage
 	if msg.Channel == "system" {
-		return al.processSystemMessage(ctx, msg)
+		response, err := al.processSystemMessage(ctx, msg)
+		return response, nil, err
 	}
 
 	if !al.toolProfile.isSideLane() && strings.TrimSpace(msg.SessionKey) != "" && len(msg.Media) > 0 {
@@ -700,7 +718,7 @@ func (al *AgentLoop) processMessageWithProgress(ctx context.Context, msg bus.Inb
 		SenderID:        msg.Channel + ":" + msg.SenderID,
 		SenderName:      msg.Metadata["username"],
 	})
-	return result.FinalContent, err
+	return result.FinalContent, result.Media, err
 }
 
 func (al *AgentLoop) processSystemMessage(ctx context.Context, msg bus.InboundMessage) (string, error) {
@@ -970,6 +988,7 @@ func (al *AgentLoop) runAgentLoop(ctx context.Context, opts processOptions) (llm
 	finalContent := iterResult.FinalContent
 	iteration := iterResult.Iterations
 	usage := iterResult.Usage
+	media := iterResult.Media
 	messageToolSent := al.messageToolSentInRound()
 
 	// If last tool had ForUser content and we already sent it, we might not need to send final response
@@ -988,7 +1007,7 @@ func (al *AgentLoop) runAgentLoop(ctx context.Context, opts processOptions) (llm
 					"session_key": opts.SessionKey,
 					"iterations":  iteration,
 				})
-		} else {
+		} else if len(media) == 0 {
 			finalContent = opts.DefaultResponse
 		}
 	}
@@ -1004,6 +1023,7 @@ func (al *AgentLoop) runAgentLoop(ctx context.Context, opts processOptions) (llm
 				"session_key":       opts.SessionKey,
 				"iterations":        iteration,
 				"message_tool_sent": messageToolSent,
+				"media_count":       len(media),
 			})
 	}
 	sessionSaveStartedAt := time.Now()
@@ -1026,13 +1046,18 @@ func (al *AgentLoop) runAgentLoop(ctx context.Context, opts processOptions) (llm
 	}
 
 	// 8. Optional: send response via bus
-	if opts.SendResponse && strings.TrimSpace(finalContent) != "" {
+	if opts.SendResponse && (strings.TrimSpace(finalContent) != "" || len(media) > 0) {
 		outboundStartedAt := time.Now()
 		emitProgress(opts.OnProgress, "replying", "Replying")
+		content := finalContent
+		if strings.TrimSpace(content) == "" && len(media) > 0 {
+			content = "Generated image."
+		}
 		al.bus.PublishOutbound(ctx, bus.OutboundMessage{
-			Channel: opts.Channel,
-			ChatID:  opts.ChatID,
-			Content: finalContent,
+			Channel:     opts.Channel,
+			ChatID:      opts.ChatID,
+			Content:     content,
+			Attachments: media,
 		})
 		if localDiag != nil {
 			localDiag.OutboundMS = time.Since(outboundStartedAt).Milliseconds()
@@ -1100,6 +1125,7 @@ func (al *AgentLoop) runAgentLoop(ctx context.Context, opts processOptions) (llm
 
 	return llmIterationResult{
 		FinalContent: finalContent,
+		Media:        media,
 		Iterations:   iteration,
 		Usage:        usage,
 		TurnErr:      iterResult.TurnErr,
@@ -1282,6 +1308,7 @@ func addUsageFields(m map[string]interface{}, u *providers.UsageInfo) {
 func (al *AgentLoop) runLLMIteration(ctx context.Context, messages []providers.Message, opts processOptions, localDiag *localTurnDiagnostics) (llmIterationResult, error) {
 	iteration := 0
 	var finalContent string
+	var collectedMedia []bus.OutboundAttachment
 	var lastMessageToolContent string
 	var usage turnUsage
 	asyncToolUsed := false
@@ -1302,7 +1329,7 @@ func (al *AgentLoop) runLLMIteration(ctx context.Context, messages []providers.M
 			if finalContent == "" {
 				if lastMessageToolContent != "" {
 					finalContent = lastMessageToolContent
-				} else {
+				} else if len(collectedMedia) == 0 {
 					finalContent = fmt.Sprintf("Iteration limit reached (%d) before task completion. Increase `agents.defaults.max_tool_iterations` or set it to 0 for no hard cap.", al.maxIterations)
 				}
 			}
@@ -1404,6 +1431,12 @@ func (al *AgentLoop) runLLMIteration(ctx context.Context, messages []providers.M
 			localDiag.recordLLMResponse(time.Since(llmCallStartedAt), response)
 		}
 		usage.add(response.Usage)
+		if len(response.Media) > 0 {
+			saved := al.persistProviderMedia(response.Media)
+			if len(saved) > 0 {
+				collectedMedia = append(collectedMedia, saved...)
+			}
+		}
 		llmCompleteFields := map[string]interface{}{
 			"turn_id":          opts.TurnID,
 			"iteration":        iteration,
@@ -1411,6 +1444,7 @@ func (al *AgentLoop) runLLMIteration(ctx context.Context, messages []providers.M
 			"duration_ms":      time.Since(llmCallStartedAt).Milliseconds(),
 			"response_chars":   len(response.Content),
 			"tool_calls_count": len(response.ToolCalls),
+			"media_count":      len(response.Media),
 		}
 		if response.Diagnostics != nil {
 			if source := strings.TrimSpace(response.Diagnostics.ContentSource); source != "" {
@@ -1716,6 +1750,7 @@ Either call the appropriate tool now, or give an honest present-tense status of 
 
 	return llmIterationResult{
 		FinalContent: finalContent,
+		Media:        collectedMedia,
 		Iterations:   iteration,
 		Usage:        usage,
 		TurnErr:      turnErr,

--- a/pkg/cron/service.go
+++ b/pkg/cron/service.go
@@ -1,6 +1,7 @@
 package cron
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -324,6 +325,12 @@ func (cs *CronService) loadStore() error {
 			return nil
 		}
 		return err
+	}
+
+	// Treat empty/whitespace files as an empty store. An empty jobs.json is a
+	// common leftover from interrupted writes and should not block gateway start.
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil
 	}
 
 	return json.Unmarshal(data, cs.store)

--- a/pkg/cron/service_test.go
+++ b/pkg/cron/service_test.go
@@ -33,6 +33,28 @@ func TestSaveStore_FilePermissions(t *testing.T) {
 	}
 }
 
+func TestLoadStore_EmptyFileStartsClean(t *testing.T) {
+	tmpDir := t.TempDir()
+	storePath := filepath.Join(tmpDir, "cron", "jobs.json")
+	if err := os.MkdirAll(filepath.Dir(storePath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(storePath, []byte(""), 0o600); err != nil {
+		t.Fatalf("write empty store: %v", err)
+	}
+
+	cs := NewCronService(storePath, nil)
+	if err := cs.Start(); err != nil {
+		t.Fatalf("Start() with empty store = %v", err)
+	}
+	defer cs.Stop()
+
+	jobs := cs.ListJobs(false)
+	if len(jobs) != 0 {
+		t.Fatalf("jobs=%d want 0", len(jobs))
+	}
+}
+
 func int64Ptr(v int64) *int64 {
 	return &v
 }

--- a/pkg/providers/codex_provider.go
+++ b/pkg/providers/codex_provider.go
@@ -2,9 +2,11 @@ package providers
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
@@ -231,7 +233,7 @@ func resolveToolCallArguments(tc ToolCall) string {
 }
 
 func translateToolsForCodex(tools []ToolDefinition) []responses.ToolUnionParam {
-	result := make([]responses.ToolUnionParam, 0, len(tools))
+	result := make([]responses.ToolUnionParam, 0, len(tools)+1)
 	for _, t := range tools {
 		ft := responses.FunctionToolParam{
 			Name:       t.Function.Name,
@@ -243,12 +245,21 @@ func translateToolsForCodex(tools []ToolDefinition) []responses.ToolUnionParam {
 		}
 		result = append(result, responses.ToolUnionParam{OfFunction: &ft})
 	}
+	// Hosted Responses image tool. Microtested against chatgpt.com Codex backend
+	// with gpt-5.5 OAuth: the model emits image_generation_call items when asked
+	// to generate an image. Keep this ahead of function tools so the model can
+	// choose it without a local generate_image function.
+	result = append(result, responses.ToolUnionParam{
+		OfImageGeneration: &responses.ToolImageGenerationParam{},
+	})
 	return result
 }
 
 func parseCodexResponse(resp *responses.Response) *LLMResponse {
 	var content strings.Builder
 	var toolCalls []ToolCall
+	var media []MediaAttachment
+	imageIndex := 0
 
 	for _, item := range resp.Output {
 		switch item.Type {
@@ -268,6 +279,11 @@ func parseCodexResponse(resp *responses.Response) *LLMResponse {
 				Name:      item.Name,
 				Arguments: args,
 			})
+		case "image_generation_call":
+			if att, ok := mediaFromCodexImageCall(item.Result, imageIndex); ok {
+				media = append(media, att)
+				imageIndex++
+			}
 		}
 	}
 
@@ -291,9 +307,33 @@ func parseCodexResponse(resp *responses.Response) *LLMResponse {
 	return &LLMResponse{
 		Content:      content.String(),
 		ToolCalls:    toolCalls,
+		Media:        media,
 		FinishReason: finishReason,
 		Usage:        usage,
 	}
+}
+
+func mediaFromCodexImageCall(result string, index int) (MediaAttachment, bool) {
+	raw := strings.TrimSpace(result)
+	if raw == "" {
+		return MediaAttachment{}, false
+	}
+	if comma := strings.Index(raw, ","); strings.HasPrefix(raw, "data:") && comma > 0 {
+		raw = raw[comma+1:]
+	}
+	data, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		data, err = base64.RawStdEncoding.DecodeString(raw)
+	}
+	if err != nil || len(data) == 0 {
+		return MediaAttachment{}, false
+	}
+	filename := fmt.Sprintf("generated-%s-%d.png", time.Now().UTC().Format("20060102-150405"), index+1)
+	return MediaAttachment{
+		Filename: filename,
+		MIME:     "image/png",
+		Data:     data,
+	}, true
 }
 
 func createCodexTokenSource() func() (string, string, error) {

--- a/pkg/providers/codex_provider_test.go
+++ b/pkg/providers/codex_provider_test.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -113,14 +114,84 @@ func TestBuildCodexParams_WithTools(t *testing.T) {
 		},
 	}
 	params := buildCodexParams([]Message{{Role: "user", Content: "Hi"}}, tools, "gpt-4o", map[string]interface{}{})
-	if len(params.Tools) != 1 {
-		t.Fatalf("len(Tools) = %d, want 1", len(params.Tools))
+	if len(params.Tools) != 2 {
+		t.Fatalf("len(Tools) = %d, want 2 (function + image_generation)", len(params.Tools))
 	}
 	if params.Tools[0].OfFunction == nil {
-		t.Fatal("Tool should be a function tool")
+		t.Fatal("first tool should be a function tool")
 	}
 	if params.Tools[0].OfFunction.Name != "get_weather" {
 		t.Errorf("Tool name = %q, want %q", params.Tools[0].OfFunction.Name, "get_weather")
+	}
+	if params.Tools[1].OfImageGeneration == nil {
+		t.Fatal("second tool should be image_generation")
+	}
+}
+
+func TestParseCodexResponse_ImageGenerationCall(t *testing.T) {
+	// 1x1 PNG
+	png := []byte{
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+		0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+		0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41,
+		0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00,
+		0x00, 0x00, 0x03, 0x00, 0x01, 0x00, 0x05, 0xfe,
+		0xd4, 0xef, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45,
+		0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+	}
+	b64 := base64.StdEncoding.EncodeToString(png)
+	respJSON := fmt.Sprintf(`{
+		"id": "resp_test",
+		"object": "response",
+		"status": "completed",
+		"output": [
+			{
+				"id": "ig_1",
+				"type": "image_generation_call",
+				"status": "completed",
+				"result": %q
+			},
+			{
+				"id": "msg_1",
+				"type": "message",
+				"role": "assistant",
+				"status": "completed",
+				"content": [
+					{"type": "output_text", "text": "Here is your image."}
+				]
+			}
+		],
+		"usage": {
+			"input_tokens": 10,
+			"output_tokens": 5,
+			"total_tokens": 15,
+			"input_tokens_details": {"cached_tokens": 0},
+			"output_tokens_details": {"reasoning_tokens": 0}
+		}
+	}`, b64)
+
+	var resp responses.Response
+	if err := json.Unmarshal([]byte(respJSON), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	result := parseCodexResponse(&resp)
+	if result.Content != "Here is your image." {
+		t.Errorf("Content = %q, want %q", result.Content, "Here is your image.")
+	}
+	if len(result.Media) != 1 {
+		t.Fatalf("len(Media) = %d, want 1", len(result.Media))
+	}
+	if result.Media[0].MIME != "image/png" {
+		t.Errorf("MIME = %q, want image/png", result.Media[0].MIME)
+	}
+	if len(result.Media[0].Data) != len(png) {
+		t.Fatalf("media bytes = %d, want %d", len(result.Media[0].Data), len(png))
+	}
+	if result.FinishReason != "stop" {
+		t.Errorf("FinishReason = %q, want stop", result.FinishReason)
 	}
 }
 

--- a/pkg/providers/types.go
+++ b/pkg/providers/types.go
@@ -15,9 +15,21 @@ type FunctionCall struct {
 	Arguments string `json:"arguments"`
 }
 
+// MediaAttachment is binary media produced by a provider turn (for example
+// OpenAI Responses image_generation_call output). Prefer Path when the bytes
+// are already on disk; otherwise Data holds decoded image bytes for the agent
+// to persist under the workspace.
+type MediaAttachment struct {
+	Filename string `json:"filename,omitempty"`
+	MIME     string `json:"mime,omitempty"`
+	Path     string `json:"path,omitempty"`
+	Data     []byte `json:"-"`
+}
+
 type LLMResponse struct {
 	Content      string               `json:"content"`
 	ToolCalls    []ToolCall           `json:"tool_calls,omitempty"`
+	Media        []MediaAttachment    `json:"media,omitempty"`
 	FinishReason string               `json:"finish_reason"`
 	Usage        *UsageInfo           `json:"usage,omitempty"`
 	Diagnostics  *ResponseDiagnostics `json:"diagnostics,omitempty"`

--- a/pkg/workspacetpl/templates/workspace/AGENTS.md
+++ b/pkg/workspacetpl/templates/workspace/AGENTS.md
@@ -46,6 +46,7 @@ Treat them as a starting pack, not a fixed identity. Keep, remove, or extend as 
 - `quarto-authoring`: reproducible manuscript rendering
 - `pandoc-docx`: clean first-draft Word generation from Markdown (bundled NIH template auto-applied)
 - `imagemagick`: reproducible image preprocessing (resize/crop/convert/DPI normalization)
+- OpenAI image generation (Codex/Responses `image_generation` tool): use when the user asks to generate or illustrate an image in chat. Do not present generated images as real experimental data. Prefer `beautiful-mermaid` for diagrams and `imagemagick` for editing existing files.
 - `beautiful-mermaid`: diagram quality and export consistency
 - `explainer-site`: deep-dive, educational single-page explainer site creation
 - `experiment-provenance`: claim-to-artifact traceability


### PR DESCRIPTION
## Summary
- Enable OpenAI Responses hosted `image_generation` on Codex turns
- Persist generated PNGs and attach them on outbound chat messages
- Surface the hosted tool in the prompt catalog when Codex is active
- Treat empty `cron/jobs.json` as an empty store
- Docs: changelog, README, announcement for v0.3.5

## Status
**Merged to `main`** (`ec0ffdac`) and previously shipped as brew **v0.3.5** on data3.

- Release: https://github.com/drpedapati/sciclaw/releases/tag/v0.3.5
- Merge: https://github.com/drpedapati/sciclaw/pull/124

## Test plan
- [x] `go test ./pkg/providers/ ./pkg/agent/ ./pkg/cron/`
- [x] data3 smoke: Discord image generation
- [x] brew stable `v0.3.5` installed on data3; Discord + cron start cleanly