### PR TITLE
fix(codex): unlock gpt-5.6-luna with Codex identity headers

### DIFF
--- a/cmd/picoclaw/tui/tab_login.go
+++ b/cmd/picoclaw/tui/tab_login.go
@@ -233,6 +233,7 @@ func isStockOpenAIModel(model string) bool {
 	switch strings.ToLower(model) {
 	case "gpt-5.6-sol", "openai/gpt-5.6-sol",
 		"gpt-5.6-terra", "openai/gpt-5.6-terra",
+		"gpt-5.6-luna", "openai/gpt-5.6-luna",
 		"gpt-5.5", "openai/gpt-5.5",
 		"gpt-5.4", "openai/gpt-5.4",
 		"gpt-5.3-codex", "openai/gpt-5.3-codex",

--- a/docs/ops/correspondence-gpt56-sol-codex-harness-remediation.md
+++ b/docs/ops/correspondence-gpt56-sol-codex-harness-remediation.md
@@ -39,7 +39,7 @@ Streamed `POST https://chatgpt.com/backend-api/codex/responses` with `stream: tr
 |-------|--------|
 | **`gpt-5.6-sol`** | HTTP 200, completed, text `ok` |
 | `gpt-5.6-terra` | HTTP 200, completed |
-| `gpt-5.6-luna` | HTTP 404 Model not found (this account/backend) |
+| `gpt-5.6-luna` | HTTP 200 with Codex CLI identity headers (`originator`+`version>=0.144.0`); bare OAuth → 404 |
 | `gpt-5.5` / `gpt-5.4` | still OK |
 | `gpt-5.2` (repo default) | **400 not supported** for Codex + ChatGPT account |
 
@@ -105,7 +105,7 @@ Streamed `POST https://chatgpt.com/backend-api/codex/responses` with `stream: tr
 ### Non-goals
 
 - Full rebase onto sipeed/picoclaw provider packages.
-- Luna on Codex until preflight is green.
+- Luna needs Codex identity headers (`originator` + `version>=0.144.0`); bare OAuth 404s.
 - API-key Chat Completions image gen (separate image-gen backlog).
 - Raising global Sol effort above **low** without a cost review (Discord multi-turn).
 - Waiting for upstream to “do 5.6 first” (they have not).
@@ -243,7 +243,7 @@ Implement:
 2. pkg/providers/codex_provider.go GetDefaultModel → "gpt-5.6-sol"
 3. config/config.example.json: model + reasoning_effort low
 4. pkg/models/models.go OpenAI catalog list: prepend "gpt-5.6-sol", "gpt-5.6-terra"
-   (do NOT add gpt-5.6-luna until Codex preflight is green)
+   (Luna is available when Codex identity headers are sent; catalog includes gpt-5.6-luna)
 5. cmd/picoclaw/tui/tab_login.go isStockOpenAIModel: include gpt-5.6-sol and openai/gpt-5.6-sol (and terra variants)
 6. TUI placeholders / settings sample maps that hardcode gpt-5.2 → update where they represent "current default"
 7. README.md OpenAI model table: primary gpt-5.6-sol @ low; note Terra as cheaper peer; leave 5.5/5.4 as still supported
@@ -468,7 +468,7 @@ sciclaw service status
 |----------|--------|-----------|
 | Primary model | `gpt-5.6-sol` | Matches product intent + ClinVision Sol; preflight green |
 | Effort | `low` | Cost/latency for Discord; ClinVision Sol consult policy |
-| Luna | Deferred | Codex 404 preflight |
+| Luna | Available | Needs Codex identity headers (`version>=0.144.0`) |
 | Upstream merge of provider tree | **Reject for this train** | Would drop image gen / effort without a large port |
 | Min ship | Config cutover Phases 0–2 | Unblocks prod without release |
 | Default ship | + Phase 3 | New installs match prod |

--- a/docs/ops/gpt56-sol-prod-switchover.md
+++ b/docs/ops/gpt56-sol-prod-switchover.md
@@ -42,7 +42,7 @@ Streamed Responses calls to `https://chatgpt.com/backend-api/codex/responses` wi
 |----------|------|--------|
 | **`gpt-5.6-sol`** | 200 | `status=completed`, text `ok`, model echoed `gpt-5.6-sol` |
 | **`gpt-5.6-terra`** | 200 | same shape |
-| `gpt-5.6-luna` | 404 | `Model not found gpt-5.6-luna` on this Codex/ChatGPT account |
+| `gpt-5.6-luna` | 200 with Codex identity | Needs `originator=codex_cli_rs` + `version>=0.144.0`; bare requests 404 `Model not found` |
 | `gpt-5.5` | 200 | still works |
 | `gpt-5.4` | 200 | still works |
 | `gpt-5.2` | 400 | **not supported** for Codex + ChatGPT account |
@@ -51,7 +51,7 @@ Streamed Responses calls to `https://chatgpt.com/backend-api/codex/responses` wi
 **Implications:**
 
 - **Target ID `gpt-5.6-sol` is correct** for the production Codex/OAuth path.
-- **Do not plan Luna** for data3 until the Codex backend lists it (API/platform may differ).
+- **Luna works** on this Pro account when Codex CLI identity headers are present (`originator=codex_cli_rs`, `version>=0.144.0`).
 - Repo default `gpt-5.2` is a **bad Codex/ChatGPT default** today — Sol is both the product target and a better Codex-compatible default.
 - Preflight used **low** effort successfully; matches ClinVision’s Sol policy for bounded work.
 
@@ -165,4 +165,4 @@ go run ./cmd/picoclaw agent --model gpt-5.6-sol --effort low -m "Reply with exac
 - **Model:** `gpt-5.6-sol` (not Terra) — matches “use gpt sol” and ClinVision’s Sol choice for strong general work.  
 - **Effort:** `low` — matches ClinVision Sol consult policy and cost/latency for a Discord gateway.  
 - **Protocol:** stay on existing Codex Responses path; no gateway rewrite.  
-- **Luna:** deferred (404 on Codex preflight).  
+- **Luna:** available with Codex identity headers (`originator`/`version`); catalog includes `gpt-5.6-luna`. Product default stays Sol.  

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -97,7 +97,7 @@ func ListProviders(cfg *config.Config) []ProviderInfo {
 		"claude-sonnet-4.6", "claude-opus-4-6", "claude-haiku-4-5-20251001",
 	})
 	add("openai", cfg.Providers.OpenAI, []string{
-		"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.5", "gpt-5.4", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.2-codex", "gpt-5.2",
+		"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.2-codex", "gpt-5.2",
 	})
 	add("openrouter", cfg.Providers.OpenRouter, []string{
 		"openrouter/<model>",
@@ -400,7 +400,7 @@ func knownModelsForProvider(provider string) []string {
 	case "anthropic":
 		return []string{"claude-sonnet-4.6", "claude-opus-4-6", "claude-haiku-4-5-20251001"}
 	case "openai":
-		return []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.5", "gpt-5.4", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.2-codex", "gpt-5.2"}
+		return []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.2-codex", "gpt-5.2"}
 	case "gemini":
 		return []string{"gemini-2.5-pro", "gemini-2.5-flash"}
 	case "openrouter":

--- a/pkg/providers/codex_provider.go
+++ b/pkg/providers/codex_provider.go
@@ -24,12 +24,29 @@ type CodexProvider struct {
 	tokenSource func() (string, string, error)
 }
 
+// Codex ChatGPT OAuth routes GPT-5.6 models (esp. Luna) by client identity.
+// Catalog metadata sets minimal_client_version=0.144.0; without originator+version
+// Luna returns HTTP 404 "Model not found". Match current Codex CLI identity.
+const (
+	codexCLIOriginator = "codex_cli_rs"
+	codexCLIVersion    = "0.144.1"
+)
+
+func appendCodexIdentityHeaders(opts []option.RequestOption) []option.RequestOption {
+	return append(opts,
+		option.WithHeader("originator", codexCLIOriginator),
+		option.WithHeader("version", codexCLIVersion),
+		option.WithHeader("User-Agent", codexCLIOriginator+"/"+codexCLIVersion),
+	)
+}
+
 func NewCodexProvider(token, accountID string) *CodexProvider {
 	opts := []option.RequestOption{
 		option.WithBaseURL("https://chatgpt.com/backend-api/codex"),
 		option.WithAPIKey(token),
 		option.WithHTTPClient(transport.NewCloudflareClient()),
 	}
+	opts = appendCodexIdentityHeaders(opts)
 	if accountID != "" {
 		opts = append(opts, option.WithHeader("Chatgpt-Account-Id", accountID))
 	}
@@ -61,6 +78,7 @@ func (p *CodexProvider) Chat(ctx context.Context, messages []Message, tools []To
 	}
 
 	var opts []option.RequestOption
+	opts = appendCodexIdentityHeaders(opts)
 	if p.tokenSource != nil {
 		tok, accID, err := p.tokenSource()
 		if err != nil {

--- a/pkg/providers/codex_provider_test.go
+++ b/pkg/providers/codex_provider_test.go
@@ -307,6 +307,18 @@ func TestCodexProvider_ChatRoundTrip(t *testing.T) {
 			http.Error(w, "missing account id", http.StatusBadRequest)
 			return
 		}
+		if r.Header.Get("originator") != codexCLIOriginator {
+			http.Error(w, "missing originator", http.StatusBadRequest)
+			return
+		}
+		if r.Header.Get("version") != codexCLIVersion {
+			http.Error(w, "missing version", http.StatusBadRequest)
+			return
+		}
+		if r.Header.Get("User-Agent") != codexCLIOriginator+"/"+codexCLIVersion {
+			http.Error(w, "missing user-agent", http.StatusBadRequest)
+			return
+		}
 
 		var body map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -469,6 +481,7 @@ func TestResolveCodexModel(t *testing.T) {
 	}{
 		{"empty", "", fallback, true, false},
 		{"sol", "gpt-5.6-sol", "gpt-5.6-sol", false, false},
+		{"luna", "gpt-5.6-luna", "gpt-5.6-luna", false, false},
 		{"prefixed", "openai/gpt-5.6-terra", "gpt-5.6-terra", false, false},
 		{"gpt52 remapped", "gpt-5.2", fallback, true, false},
 		{"gpt52 codex kept", "gpt-5.2-codex", "gpt-5.2-codex", false, false},


### PR DESCRIPTION
## Summary
- Codex ChatGPT OAuth was omitting `originator` / `version` / versioned `User-Agent`, so `gpt-5.6-luna` 404'd while Sol/Terra worked.
- Send Codex CLI identity (`codex_cli_rs` / `0.144.1`, matching catalog `minimal_client_version`) on Codex requests.
- Add `gpt-5.6-luna` to the OpenAI catalog and stock-model list; product default remains Sol.

## Test plan
- [x] `go test ./pkg/providers/ -run 'Codex|ResolveCodex'`
- [x] `go test ./pkg/models/`
- [ ] Live data3 (after deploy): `sciclaw agent --model gpt-5.6-luna -m "Reply with exactly: ok"`
- [ ] Confirm Sol still works unchanged as default

Made with [Cursor](https://cursor.com)