### PR TITLE
feat(agent): per-turn model/effort overrides via leading directives

### DIFF
--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -114,6 +114,8 @@ type processOptions struct {
 	ChatID          string // Target chat ID for tool execution
 	TurnID          string // Deterministic turn identifier for audit and hooks
 	UserMessage     string // User message content (may include prefix)
+	Model           string // Optional per-turn model override (same provider family)
+	ReasoningEffort string // Optional per-turn reasoning effort override
 	DefaultResponse string // Response when LLM returns empty
 	EnableSummary   bool   // Whether to trigger summarization
 	SendResponse    bool   // Whether to send response via bus
@@ -739,12 +741,19 @@ func (al *AgentLoop) processMessageWithMedia(ctx context.Context, msg bus.Inboun
 		al.registerInboundArtifacts(msg.SessionKey, msg.Media)
 	}
 
+	userMessage, turnModel, turnEffort, dirErr := al.applyInboundTurnDirectives(msg)
+	if dirErr != nil {
+		return dirErr.Error(), nil, nil
+	}
+
 	// Process as user message
 	result, err := al.runAgentLoop(ctx, processOptions{
 		SessionKey:      msg.SessionKey,
 		Channel:         msg.Channel,
 		ChatID:          msg.ChatID,
-		UserMessage:     msg.Content,
+		UserMessage:     userMessage,
+		Model:           turnModel,
+		ReasoningEffort: turnEffort,
 		DefaultResponse: defaultEmptyAssistantResponse,
 		EnableSummary:   !al.toolProfile.isSideLane(),
 		SendResponse:    false,
@@ -754,6 +763,46 @@ func (al *AgentLoop) processMessageWithMedia(ctx context.Context, msg bus.Inboun
 		SenderName:      msg.Metadata["username"],
 	})
 	return result.FinalContent, result.Media, err
+}
+
+// applyInboundTurnDirectives parses leading model:/effort: lines (and optional
+// metadata) into a same-provider per-turn override. On cross-provider or bad
+// effort, returns a user-visible error and no LLM call.
+func (al *AgentLoop) applyInboundTurnDirectives(msg bus.InboundMessage) (body, model, effort string, err error) {
+	parsed := ParseTurnDirectives(msg.Content)
+	body = parsed.Body
+	if !parsed.HadDirectives {
+		body = msg.Content
+	}
+
+	reqModel := parsed.Model
+	reqEffort := parsed.Effort
+	if reqModel == "" && msg.Metadata != nil {
+		reqModel = strings.TrimSpace(msg.Metadata["model"])
+	}
+	if reqEffort == "" && msg.Metadata != nil {
+		reqEffort = strings.TrimSpace(msg.Metadata["effort"])
+	}
+	if reqModel == "" && reqEffort == "" {
+		return body, "", "", nil
+	}
+
+	model, effort, resolveErr := ResolveTurnOverrides(al.model, reqModel, reqEffort)
+	if resolveErr != nil {
+		return "", "", "", resolveErr
+	}
+	if model == al.model {
+		model = "" // keep unset so runAgentLoop uses workspace default
+	}
+	logger.InfoCF("agent", "Applied per-turn model/effort override", map[string]interface{}{
+		"channel":          msg.Channel,
+		"requested_model":  reqModel,
+		"requested_effort": reqEffort,
+		"turn_model":       model,
+		"turn_effort":      effort,
+		"workspace_model":  al.model,
+	})
+	return body, model, effort, nil
 }
 
 func (al *AgentLoop) processSystemMessage(ctx context.Context, msg bus.InboundMessage) (string, error) {
@@ -821,6 +870,11 @@ func (al *AgentLoop) runAgentLoop(ctx context.Context, opts processOptions) (llm
 		localDiag = newLocalTurnDiagnostics()
 	}
 
+	turnModel := al.model
+	if opts.Model != "" {
+		turnModel = opts.Model
+	}
+
 	// 0. Record last channel for heartbeat notifications (skip internal channels)
 	if !opts.Ephemeral && opts.Channel != "" && opts.ChatID != "" {
 		// Don't record internal channels (cli, system, subagent)
@@ -840,7 +894,7 @@ func (al *AgentLoop) runAgentLoop(ctx context.Context, opts processOptions) (llm
 		SessionKey:  opts.SessionKey,
 		Channel:     opts.Channel,
 		ChatID:      opts.ChatID,
-		Model:       al.model,
+		Model:       turnModel,
 		UserMessage: sanitizeHookText(opts.UserMessage),
 	})
 
@@ -998,7 +1052,7 @@ func (al *AgentLoop) runAgentLoop(ctx context.Context, opts processOptions) (llm
 			logFields["session_key"] = opts.SessionKey
 			logFields["channel"] = opts.Channel
 			logFields["chat_id"] = opts.ChatID
-			logFields["model"] = al.model
+			logFields["model"] = turnModel
 			logFields["local_backend"] = al.localBackend
 			logFields["iterations"] = iterResult.Iterations
 			logFields["message_tool_sent"] = messageToolSent
@@ -1011,7 +1065,7 @@ func (al *AgentLoop) runAgentLoop(ctx context.Context, opts processOptions) (llm
 			SessionKey:   opts.SessionKey,
 			Channel:      opts.Channel,
 			ChatID:       opts.ChatID,
-			Model:        al.model,
+			Model:        turnModel,
 			UserMessage:  sanitizeHookText(opts.UserMessage),
 			ErrorMessage: sanitizeHookText(err.Error()),
 			Metadata: map[string]any{
@@ -1139,7 +1193,7 @@ func (al *AgentLoop) runAgentLoop(ctx context.Context, opts processOptions) (llm
 		logFields["session_key"] = opts.SessionKey
 		logFields["channel"] = opts.Channel
 		logFields["chat_id"] = opts.ChatID
-		logFields["model"] = al.model
+		logFields["model"] = turnModel
 		logFields["local_backend"] = al.localBackend
 		logFields["iterations"] = iteration
 		logFields["message_tool_sent"] = messageToolSent
@@ -1152,7 +1206,7 @@ func (al *AgentLoop) runAgentLoop(ctx context.Context, opts processOptions) (llm
 		SessionKey:         opts.SessionKey,
 		Channel:            opts.Channel,
 		ChatID:             opts.ChatID,
-		Model:              al.model,
+		Model:              turnModel,
 		UserMessage:        sanitizeHookText(opts.UserMessage),
 		LLMResponseSummary: sanitizeHookText(finalContent),
 		Metadata:           turnMeta,
@@ -1341,6 +1395,15 @@ func addUsageFields(m map[string]interface{}, u *providers.UsageInfo) {
 // runLLMIteration executes the LLM call loop with tool handling.
 // Returns the final content, iteration count, accumulated token usage, and any error.
 func (al *AgentLoop) runLLMIteration(ctx context.Context, messages []providers.Message, opts processOptions, localDiag *localTurnDiagnostics) (llmIterationResult, error) {
+	turnModel := al.model
+	if opts.Model != "" {
+		turnModel = opts.Model
+	}
+	turnEffort := al.reasoningEffort
+	if opts.ReasoningEffort != "" {
+		turnEffort = opts.ReasoningEffort
+	}
+
 	iteration := 0
 	var finalContent string
 	var collectedMedia []bus.OutboundAttachment
@@ -1394,7 +1457,7 @@ func (al *AgentLoop) runLLMIteration(ctx context.Context, messages []providers.M
 		logger.DebugCF("agent", "LLM request",
 			map[string]interface{}{
 				"iteration":         iteration,
-				"model":             al.model,
+				"model":             turnModel,
 				"messages_count":    len(messages),
 				"tools_count":       len(providerToolDefs),
 				"max_tokens":        maxTokens,
@@ -1415,7 +1478,7 @@ func (al *AgentLoop) runLLMIteration(ctx context.Context, messages []providers.M
 			SessionKey:  opts.SessionKey,
 			Channel:     opts.Channel,
 			ChatID:      opts.ChatID,
-			Model:       al.model,
+			Model:       turnModel,
 			UserMessage: sanitizeHookText(opts.UserMessage),
 			Metadata: map[string]any{
 				"iteration":      iteration,
@@ -1429,22 +1492,22 @@ func (al *AgentLoop) runLLMIteration(ctx context.Context, messages []providers.M
 			"max_tokens":  maxTokens,
 			"temperature": 0.7,
 		}
-		if al.reasoningEffort != "" && openAIFamilyModel(al.model) {
-			llmOpts["reasoning_effort"] = al.reasoningEffort
+		if turnEffort != "" && openAIFamilyModel(turnModel) {
+			llmOpts["reasoning_effort"] = turnEffort
 		}
 		llmCallStartedAt := time.Now()
 		logger.InfoCF("agent", "LLM call start",
 			map[string]interface{}{
 				"turn_id":        opts.TurnID,
 				"iteration":      iteration,
-				"model":          al.model,
+				"model":          turnModel,
 				"channel":        opts.Channel,
 				"chat_id":        opts.ChatID,
 				"session_key":    opts.SessionKey,
 				"messages_count": len(messages),
 				"tools_count":    len(providerToolDefs),
 			})
-		response, err := al.provider.Chat(ctx, messages, providerToolDefs, al.model, llmOpts)
+		response, err := al.provider.Chat(ctx, messages, providerToolDefs, turnModel, llmOpts)
 
 		if err != nil {
 			if localDiag != nil {
@@ -1497,7 +1560,7 @@ func (al *AgentLoop) runLLMIteration(ctx context.Context, messages []providers.M
 			SessionKey:         opts.SessionKey,
 			Channel:            opts.Channel,
 			ChatID:             opts.ChatID,
-			Model:              al.model,
+			Model:              turnModel,
 			UserMessage:        sanitizeHookText(opts.UserMessage),
 			LLMResponseSummary: sanitizeHookText(response.Content),
 			Metadata: map[string]any{
@@ -1620,7 +1683,7 @@ Either call the appropriate tool now, or give an honest present-tense status of 
 				SessionKey: opts.SessionKey,
 				Channel:    opts.Channel,
 				ChatID:     opts.ChatID,
-				Model:      al.model,
+				Model:      turnModel,
 				ToolName:   tc.Name,
 				ToolArgs:   sanitizeHookArgs(tc.Arguments),
 				Metadata: map[string]any{
@@ -1745,7 +1808,7 @@ Either call the appropriate tool now, or give an honest present-tense status of 
 				SessionKey: opts.SessionKey,
 				Channel:    opts.Channel,
 				ChatID:     opts.ChatID,
-				Model:      al.model,
+				Model:      turnModel,
 				ToolName:   tc.Name,
 				ToolArgs:   sanitizeHookArgs(tc.Arguments),
 				ToolResult: sanitizeHookText(contentForLLM),
@@ -1766,7 +1829,7 @@ Either call the appropriate tool now, or give an honest present-tense status of 
 					SessionKey:   opts.SessionKey,
 					Channel:      opts.Channel,
 					ChatID:       opts.ChatID,
-					Model:        al.model,
+					Model:        turnModel,
 					ToolName:     tc.Name,
 					ToolArgs:     sanitizeHookArgs(tc.Arguments),
 					ErrorMessage: sanitizeHookText(errMsg),

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -21,6 +21,87 @@ import (
 	"github.com/sipeed/picoclaw/pkg/tools"
 )
 
+func TestProcessDirect_TurnDirectivesOverrideModelAndEffort(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         tmpDir,
+				Model:             "gpt-5.6-sol",
+				ReasoningEffort:   "low",
+				MaxTokens:         4096,
+				MaxToolIterations: 5,
+			},
+		},
+	}
+	provider := &recordingProvider{}
+	al := NewAgentLoop(cfg, bus.NewMessageBus(), provider)
+	defer al.Stop()
+
+	got, err := al.ProcessDirect(context.Background(), "model: luna\neffort: high\nSay only: ping", "turn-directives")
+	if len(provider.models) == 0 {
+		t.Fatalf("expected provider Chat call (err=%v got=%q)", err, got)
+	}
+	if provider.models[0] != "gpt-5.6-luna" {
+		t.Fatalf("model=%q want gpt-5.6-luna", provider.models[0])
+	}
+	if provider.efforts[0] != "high" {
+		t.Fatalf("effort=%q want high", provider.efforts[0])
+	}
+	// Directive lines must not reach the LLM user message.
+	for _, msg := range provider.lastMessages {
+		if msg.Role == "user" && strings.Contains(msg.Content, "model: luna") {
+			t.Fatalf("directive leaked into user message: %q", msg.Content)
+		}
+	}
+}
+
+func TestProcessDirect_TurnDirectivesRejectCrossProvider(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:         tmpDir,
+				Model:             "gpt-5.6-sol",
+				MaxTokens:         4096,
+				MaxToolIterations: 5,
+			},
+		},
+	}
+	provider := &recordingProvider{}
+	al := NewAgentLoop(cfg, bus.NewMessageBus(), provider)
+	defer al.Stop()
+
+	got, err := al.ProcessDirect(context.Background(), "model: sonnet\nhello", "turn-directives-xprov")
+	if err != nil {
+		t.Fatalf("ProcessDirect: %v", err)
+	}
+	if !strings.Contains(got, "anthropic") && !strings.Contains(strings.ToLower(got), "same-provider") {
+		t.Fatalf("expected cross-provider rejection message, got %q", got)
+	}
+	if len(provider.models) != 0 {
+		t.Fatalf("expected no LLM call, got models=%v", provider.models)
+	}
+}
+
+type recordingProvider struct {
+	models       []string
+	efforts      []string
+	lastMessages []providers.Message
+}
+
+func (m *recordingProvider) Chat(ctx context.Context, messages []providers.Message, tools []providers.ToolDefinition, model string, opts map[string]interface{}) (*providers.LLMResponse, error) {
+	m.models = append(m.models, model)
+	effort, _ := opts["reasoning_effort"].(string)
+	m.efforts = append(m.efforts, effort)
+	m.lastMessages = messages
+	return &providers.LLMResponse{Content: "ok"}, nil
+}
+
+func (m *recordingProvider) GetDefaultModel() string {
+	return "gpt-5.6-sol"
+}
+
 // mockProvider is a simple mock LLM provider for testing
 type mockProvider struct{}
 

--- a/pkg/agent/turn_directives.go
+++ b/pkg/agent/turn_directives.go
@@ -36,6 +36,10 @@ var allowedEfforts = map[string]bool{
 
 // ParseTurnDirectives extracts leading model:/effort: lines (or a combined
 // first line) from content. The remainder is returned as Body.
+//
+// Leading Discord leftovers like "@sciClaw model: luna" (typed name after a
+// real <@bot> mention was stripped) are accepted — @tokens before the
+// directive are ignored.
 func ParseTurnDirectives(content string) TurnDirectives {
 	trimmed := strings.TrimSpace(content)
 	if trimmed == "" {
@@ -53,6 +57,14 @@ func ParseTurnDirectives(content string) TurnDirectives {
 				continue
 			}
 			break
+		}
+
+		// Drop leading @mention tokens (@sciClaw, <@id>, <@!id>) so Discord
+		// paste patterns still parse.
+		line = stripLeadingMentionTokens(line)
+		if line == "" {
+			i++
+			continue
 		}
 
 		lower := strings.ToLower(line)
@@ -105,6 +117,33 @@ func ParseTurnDirectives(content string) TurnDirectives {
 		Effort:        strings.TrimSpace(effort),
 		Body:          body,
 		HadDirectives: true,
+	}
+}
+
+func stripLeadingMentionTokens(line string) string {
+	s := strings.TrimSpace(line)
+	for {
+		switch {
+		case strings.HasPrefix(s, "<@"):
+			end := strings.IndexByte(s, '>')
+			if end < 0 {
+				return s
+			}
+			s = strings.TrimSpace(s[end+1:])
+		case strings.HasPrefix(s, "@"):
+			// @sciClaw or @name — consume one token
+			rest := strings.TrimSpace(s[1:])
+			if rest == "" {
+				return ""
+			}
+			parts := strings.Fields(rest)
+			if len(parts) == 0 {
+				return ""
+			}
+			s = strings.TrimSpace(strings.TrimPrefix(rest, parts[0]))
+		default:
+			return s
+		}
 	}
 }
 

--- a/pkg/agent/turn_directives.go
+++ b/pkg/agent/turn_directives.go
@@ -1,0 +1,212 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TurnDirectives are optional leading model/effort hints stripped from the
+// user message before the LLM sees it.
+type TurnDirectives struct {
+	Model         string
+	Effort        string
+	Body          string
+	HadDirectives bool
+}
+
+var modelAliases = map[string]string{
+	"luna":   "gpt-5.6-luna",
+	"sol":    "gpt-5.6-sol",
+	"terra":  "gpt-5.6-terra",
+	"sonnet": "claude-sonnet-4.6",
+	"opus":   "claude-opus-4-6",
+	"haiku":  "claude-haiku-4-5-20251001",
+}
+
+var allowedEfforts = map[string]bool{
+	"low":     true,
+	"medium":  true,
+	"high":    true,
+	"xhigh":   true,
+	"max":     true,
+	"ultra":   true,
+	"minimal": true,
+	"none":    true,
+}
+
+// ParseTurnDirectives extracts leading model:/effort: lines (or a combined
+// first line) from content. The remainder is returned as Body.
+func ParseTurnDirectives(content string) TurnDirectives {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return TurnDirectives{Body: content}
+	}
+
+	lines := strings.Split(content, "\n")
+	var model, effort string
+	i := 0
+	for i < len(lines) {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			if model != "" || effort != "" {
+				i++
+				continue
+			}
+			break
+		}
+
+		lower := strings.ToLower(line)
+		parsedAny := false
+
+		// Combined first-line form: "model: luna effort: high"
+		if m, rest, ok := cutDirective(lower, line, "model:"); ok {
+			model = m
+			parsedAny = true
+			if e, _, ok := cutDirective(strings.ToLower(rest), rest, "effort:"); ok {
+				effort = e
+			} else if e, _, ok := cutDirective(strings.ToLower(rest), rest, "reasoning:"); ok {
+				effort = e
+			} else if e, _, ok := cutDirective(strings.ToLower(rest), rest, "reasoning_effort:"); ok {
+				effort = e
+			}
+			i++
+			continue
+		}
+		if e, _, ok := cutDirective(lower, line, "effort:"); ok {
+			effort = e
+			parsedAny = true
+			i++
+			continue
+		}
+		if e, _, ok := cutDirective(lower, line, "reasoning:"); ok {
+			effort = e
+			parsedAny = true
+			i++
+			continue
+		}
+		if e, _, ok := cutDirective(lower, line, "reasoning_effort:"); ok {
+			effort = e
+			parsedAny = true
+			i++
+			continue
+		}
+		if !parsedAny {
+			break
+		}
+	}
+
+	if model == "" && effort == "" {
+		return TurnDirectives{Body: content}
+	}
+
+	body := strings.TrimSpace(strings.Join(lines[i:], "\n"))
+	return TurnDirectives{
+		Model:         strings.TrimSpace(model),
+		Effort:        strings.TrimSpace(effort),
+		Body:          body,
+		HadDirectives: true,
+	}
+}
+
+func cutDirective(lowerLine, originalLine, prefix string) (value, rest string, ok bool) {
+	if !strings.HasPrefix(lowerLine, prefix) {
+		return "", "", false
+	}
+	// Preserve original casing for the value by slicing originalLine.
+	raw := strings.TrimSpace(originalLine[len(prefix):])
+	if raw == "" {
+		return "", "", true
+	}
+	// Split off another directive on the same line.
+	fields := strings.Fields(raw)
+	if len(fields) == 0 {
+		return "", "", true
+	}
+	valParts := []string{fields[0]}
+	restStart := 1
+	for restStart < len(fields) {
+		f := strings.ToLower(fields[restStart])
+		if strings.HasPrefix(f, "model:") || strings.HasPrefix(f, "effort:") ||
+			strings.HasPrefix(f, "reasoning:") || strings.HasPrefix(f, "reasoning_effort:") {
+			break
+		}
+		valParts = append(valParts, fields[restStart])
+		restStart++
+	}
+	value = strings.Join(valParts, " ")
+	if restStart < len(fields) {
+		rest = strings.Join(fields[restStart:], " ")
+	}
+	return value, rest, true
+}
+
+// ResolveTurnOverrides maps aliases and enforces same-provider-family scope
+// relative to the workspace default model. effort-only overrides are always OK.
+func ResolveTurnOverrides(defaultModel, requestedModel, requestedEffort string) (model, effort string, err error) {
+	model = strings.TrimSpace(defaultModel)
+	if requestedModel != "" {
+		resolved := expandModelAlias(requestedModel)
+		defFam := modelProviderFamily(defaultModel)
+		reqFam := modelProviderFamily(resolved)
+		if defFam == "" || reqFam == "" {
+			return "", "", fmt.Errorf("could not resolve provider family for model override %q", requestedModel)
+		}
+		if defFam != reqFam {
+			return "", "", fmt.Errorf(
+				"model %q is a %s model, but this workspace is running %s (%s). Same-provider overrides only — try a %s model",
+				requestedModel, reqFam, defaultModel, defFam, defFam,
+			)
+		}
+		model = resolved
+	}
+
+	if requestedEffort != "" {
+		e := strings.ToLower(strings.TrimSpace(requestedEffort))
+		if !allowedEfforts[e] {
+			return "", "", fmt.Errorf("unknown effort %q (want low|medium|high|xhigh|max|ultra|minimal|none)", requestedEffort)
+		}
+		effort = e
+	}
+	return model, effort, nil
+}
+
+func expandModelAlias(raw string) string {
+	s := strings.TrimSpace(raw)
+	s = strings.TrimPrefix(s, "openai/")
+	s = strings.TrimPrefix(s, "anthropic/")
+	if alias, ok := modelAliases[strings.ToLower(s)]; ok {
+		return alias
+	}
+	return s
+}
+
+// modelProviderFamily is a cfg-free heuristic aligned with models.ResolveProvider.
+func modelProviderFamily(model string) string {
+	lower := strings.ToLower(strings.TrimSpace(model))
+	if lower == "" {
+		return ""
+	}
+	if strings.Contains(lower, "claude") || strings.HasPrefix(lower, "anthropic/") {
+		return "anthropic"
+	}
+	if strings.Contains(lower, "gpt") || strings.Contains(lower, "o1") || strings.Contains(lower, "o3") ||
+		strings.Contains(lower, "o4") || strings.Contains(lower, "codex") || strings.HasPrefix(lower, "openai/") {
+		return "openai"
+	}
+	if strings.Contains(lower, "gemini") || strings.HasPrefix(lower, "google/") {
+		return "gemini"
+	}
+	if strings.Contains(lower, "glm") || strings.Contains(lower, "zhipu") {
+		return "zhipu"
+	}
+	if strings.Contains(lower, "groq") || strings.HasPrefix(lower, "groq/") {
+		return "groq"
+	}
+	if strings.Contains(lower, "deepseek") {
+		return "deepseek"
+	}
+	if strings.HasPrefix(lower, "openrouter/") || strings.HasPrefix(lower, "meta-llama/") {
+		return "openrouter"
+	}
+	return ""
+}

--- a/pkg/agent/turn_directives_test.go
+++ b/pkg/agent/turn_directives_test.go
@@ -47,6 +47,22 @@ func TestParseTurnDirectives(t *testing.T) {
 			wantHad:    true,
 		},
 		{
+			name:       "discord leftover @name before model",
+			in:         "@sciClaw model: luna\neffort: high\nSay only: PING_LUNA_HIGH",
+			wantModel:  "luna",
+			wantEffort: "high",
+			wantBody:   "Say only: PING_LUNA_HIGH",
+			wantHad:    true,
+		},
+		{
+			name:       "discord mention id then model",
+			in:         "<@1476615906376548544> model: sol\neffort: low\nping",
+			wantModel:  "sol",
+			wantEffort: "low",
+			wantBody:   "ping",
+			wantHad:    true,
+		},
+		{
 			name:     "model mentioned mid-message ignored",
 			in:       "please use model: luna for this",
 			wantBody: "please use model: luna for this",

--- a/pkg/agent/turn_directives_test.go
+++ b/pkg/agent/turn_directives_test.go
@@ -1,0 +1,123 @@
+package agent
+
+import "testing"
+
+func TestParseTurnDirectives(t *testing.T) {
+	tests := []struct {
+		name       string
+		in         string
+		wantModel  string
+		wantEffort string
+		wantBody   string
+		wantHad    bool
+	}{
+		{
+			name:     "no directives",
+			in:       "just a normal question",
+			wantBody: "just a normal question",
+		},
+		{
+			name:      "model alias line",
+			in:        "model: luna\nsummarize notes",
+			wantModel: "luna",
+			wantBody:  "summarize notes",
+			wantHad:   true,
+		},
+		{
+			name:       "combined first line",
+			in:         "model: sol effort: high\nDo the thing",
+			wantModel:  "sol",
+			wantEffort: "high",
+			wantBody:   "Do the thing",
+			wantHad:    true,
+		},
+		{
+			name:       "split lines",
+			in:         "model: gpt-5.6-terra\neffort: low\n\nhello",
+			wantModel:  "gpt-5.6-terra",
+			wantEffort: "low",
+			wantBody:   "hello",
+			wantHad:    true,
+		},
+		{
+			name:       "effort only",
+			in:         "effort: xhigh\nping",
+			wantEffort: "xhigh",
+			wantBody:   "ping",
+			wantHad:    true,
+		},
+		{
+			name:     "model mentioned mid-message ignored",
+			in:       "please use model: luna for this",
+			wantBody: "please use model: luna for this",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseTurnDirectives(tt.in)
+			if got.Model != tt.wantModel {
+				t.Fatalf("Model=%q want %q", got.Model, tt.wantModel)
+			}
+			if got.Effort != tt.wantEffort {
+				t.Fatalf("Effort=%q want %q", got.Effort, tt.wantEffort)
+			}
+			if got.Body != tt.wantBody {
+				t.Fatalf("Body=%q want %q", got.Body, tt.wantBody)
+			}
+			if got.HadDirectives != tt.wantHad {
+				t.Fatalf("HadDirectives=%v want %v", got.HadDirectives, tt.wantHad)
+			}
+		})
+	}
+}
+
+func TestResolveTurnOverrides(t *testing.T) {
+	model, effort, err := ResolveTurnOverrides("gpt-5.6-sol", "luna", "high")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if model != "gpt-5.6-luna" || effort != "high" {
+		t.Fatalf("got model=%q effort=%q", model, effort)
+	}
+
+	_, _, err = ResolveTurnOverrides("gpt-5.6-sol", "sonnet", "")
+	if err == nil {
+		t.Fatal("expected cross-provider error")
+	}
+
+	_, _, err = ResolveTurnOverrides("claude-sonnet-4.6", "luna", "")
+	if err == nil {
+		t.Fatal("expected cross-provider error for claude workspace")
+	}
+
+	model, effort, err = ResolveTurnOverrides("claude-sonnet-4.6", "opus", "medium")
+	if err != nil {
+		t.Fatalf("claude alias: %v", err)
+	}
+	if model != "claude-opus-4-6" {
+		t.Fatalf("opus alias = %q", model)
+	}
+	// effort still validated even on anthropic (harmless if provider ignores)
+	if effort != "medium" {
+		t.Fatalf("effort=%q", effort)
+	}
+
+	_, _, err = ResolveTurnOverrides("gpt-5.6-sol", "", "nope")
+	if err == nil {
+		t.Fatal("expected bad effort error")
+	}
+
+	model, effort, err = ResolveTurnOverrides("gpt-5.6-sol", "", "low")
+	if err != nil || model != "gpt-5.6-sol" || effort != "low" {
+		t.Fatalf("effort-only got model=%q effort=%q err=%v", model, effort, err)
+	}
+}
+
+func TestModelProviderFamily(t *testing.T) {
+	if got := modelProviderFamily("gpt-5.6-luna"); got != "openai" {
+		t.Fatalf("got %q", got)
+	}
+	if got := modelProviderFamily("claude-opus-4-6"); got != "anthropic" {
+		t.Fatalf("got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Leading `model:` / `effort:` directives (aliases: luna/sol/terra/sonnet/…) for **same-provider, per-turn** overrides only.
- Cross-provider requests are rejected with a clear message (no LLM call when parsing succeeds).
- Strips leftover Discord `@name` / `<@id>` before parsing so `@sciClaw model: luna` works after the real mention is removed.

**Independent of #126** (Luna Codex identity headers). This PR does **not** include those headers — merge/deploy #126 first if you need Luna to actually resolve on Codex OAuth.

## Risk note
Directive parsing can misfire on leading lines that look like `model:` / `effort:` (or `@user model: …`). Prefer shipping #126 alone first; treat this as an opt-in product experiment.

## Test plan
- [x] Unit tests for parse/resolve + mention leftovers
- [x] `go test ./pkg/agent/ -run 'TurnDirective|ParseTurn|ResolveTurn'`
- [ ] After deploy (with #126 if testing Luna): Discord `#test` with real bot mention + `model: luna` / `effort: high`
- [ ] Confirm `Applied per-turn` + `model=gpt-5.6-luna` in gateway.log (not just a roleplayed ping)