### PR TITLE
fix(agent): preserve image-generated slide intent

### DIFF
--- a/.agents/skills/ship-job/SKILL.md
+++ b/.agents/skills/ship-job/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: ship-job
+description: Ship a SciClaw software change through an isolated worktree, implementation, pruning, verification, commit, push, draft pull request, CI closeout, and independent review. Use when asked to ship a job, complete a change through PR, prepare a release candidate, or follow the repository's happy path toward Homebrew release and Data3 deployment.
+---
+
+# Ship job
+
+Deliver a reviewable packet, not uncommitted local work. Keep implementation in an isolated worktree and preserve unrelated changes.
+
+## Authority boundary
+
+Invocation authorizes implementation, commit, push, and a draft PR. It does not by itself authorize merge, tag creation, release publication, Homebrew tap mutation, or deployment. Treat those as explicit post-review gates.
+
+## Workflow
+
+1. Reconfirm the requested outcome, acceptance criteria, exclusions, and authority.
+2. Inspect the repository root, remotes, worktrees, dirty state, base commit, related PRs, and repository guidance.
+3. Create a unique branch and isolated worktree from the evidence-backed base. Reconfirm isolation before every edit, test, commit, and publish operation.
+4. Read the governing code, tests, specifications, and skills. Implement the smallest cohesive change.
+5. Prune the complete diff: remove dead code, duplicate paths, abandoned attempts, unnecessary abstractions, stale documentation, and generated debris.
+6. Run focused tests followed by the broadest practical suite. Inspect formatting, build, `git diff --check`, status, and the complete diff. Visually inspect real renders for visual work.
+7. Perform a pre-publish review. Fix material findings and rerun affected checks.
+8. Commit only intended files, push the branch, and open a draft PR against the verified base.
+9. Add a standalone independent-review packet using `references/external-review-prompt.md` and record the closeout using `references/correspondence-template.md`.
+10. Monitor CI, mergeability, and in-scope feedback. Fix branch-caused failures without silently expanding scope.
+11. Report the ordered merge train and the next authorized action.
+
+## SciClaw release continuation
+
+When the user separately authorizes merge, release, or deployment, read `references/sciclaw-release.md` completely and follow its gates. Never tag a commit other than the reviewed merge head. Use Homebrew as the deployment source of truth; never hot-copy or symlink a development binary into the service path.
+
+## Completion contract
+
+A ship job is incomplete without:
+
+- isolated worktree and branch;
+- pruned and verified change;
+- commit and push;
+- draft PR;
+- independent-review prompt on the branch or PR;
+- CI/review status and merge train;
+- explicit limitations and next safe action.
+
+Final reporting must include worktree, branch, base, commit, PR, verification, evidence, limitations, review packet path, merge train, and the next gate.

--- a/.agents/skills/ship-job/agents/openai.yaml
+++ b/.agents/skills/ship-job/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ship Job"
+  short_description: "Ship reviewed changes through a draft PR"
+  default_prompt: "Use $ship-job to deliver this change through a verified draft pull request."

--- a/.agents/skills/ship-job/references/correspondence-template.md
+++ b/.agents/skills/ship-job/references/correspondence-template.md
@@ -1,0 +1,16 @@
+# Ship closeout
+
+Record:
+
+1. answer first: ready for review or blocked;
+2. user-visible outcome;
+3. concise architecture and intentional cleanup;
+4. worktree, branch, base, head, PR, and dirty state;
+5. ordered merge train and blockers;
+6. verification commands and observed outcomes;
+7. external evidence and visual inspection where applicable;
+8. limitations and excluded work;
+9. next authorized gate;
+10. completed independent-review prompt.
+
+Do not include secrets, credentials, PHI, or raw tokens.

--- a/.agents/skills/ship-job/references/external-review-prompt.md
+++ b/.agents/skills/ship-job/references/external-review-prompt.md
@@ -1,0 +1,18 @@
+# Independent review prompt
+
+```text
+Act as an independent senior engineer reviewing this SciClaw pull request. Do not trust the implementer's summary as proof. Inspect the exact base/head commits, full diff, tests, prompt assembly, runtime skill routing, packaging, and cited evidence.
+
+Submit findings as a GitHub review. Approve only when no material findings remain; request changes for merge blockers; comment when evidence is incomplete. Do not merge or push fixes.
+
+Verify:
+1. The diff matches the requested behavior without unrelated changes.
+2. Removed prompt language is absent from runtime, templates, documentation, and tests.
+3. Artifact routing distinguishes standalone images, slide assets, editable PowerPoint, and complete image-generated slides.
+4. Tests would fail for the prior behavior and cover important negative cases.
+5. Provider image transport, persistence, and Discord attachment behavior remain intact.
+6. Homebrew/release implications and rollback are accurately described.
+7. No dead code, duplicate paths, stale attempt leftovers, secrets, or generated debris remain.
+
+Return: verdict, findings by severity with file/line references, evidence and commands rerun, unverified claims, and minimal remediation before merge.
+```

--- a/.agents/skills/ship-job/references/sciclaw-release.md
+++ b/.agents/skills/ship-job/references/sciclaw-release.md
@@ -1,0 +1,62 @@
+# SciClaw release and deployment continuation
+
+Read this only after the draft PR is verified and the user has separately authorized the applicable merge, release, or deployment operation.
+
+## Merge gate
+
+1. Refresh the exact PR head, review decision, mergeability, and CI.
+2. Require no unresolved material review findings.
+3. Merge only with explicit authorization.
+4. Record the resulting `main` commit. All tags and release artifacts must derive from that commit.
+
+## Version gate
+
+1. Inspect the latest stable and development tags; never guess the next version.
+2. Use a new patch version after any change to an earlier canary. Never move or rewrite a published tag.
+3. Update release notes and public documentation when the change is user-visible.
+
+## Release paths
+
+Prefer the repository workflow:
+
+```bash
+make release-dispatch RELEASE_TAG=vX.Y.Z
+```
+
+For a development canary, use the repository's development release target with a fresh `-dev.N` tag. For a stable local release, `make release-local RELEASE_TAG=vX.Y.Z` requires a clean tree.
+
+Verify the GitHub workflow created the expected tag, binaries, checksums, release, and—only for a stable non-draft release—the Homebrew tap update.
+
+## Homebrew deployment contract
+
+Follow `docs/ops/brew-only-deployment-contract.md` completely. On Data3, use Linuxbrew's resolved paths.
+
+1. Snapshot the current version, resolved binary, service binding, model status, and gateway health.
+2. Run `brew update` and upgrade the intended `sciclaw` or `sciclaw-dev` formula.
+3. Refresh/reinstall the service using the active Brew binary, then restart it.
+4. Verify the binary resolves under the Brew Cellar/opt path and the service uses the same installation.
+5. Run `sciclaw doctor`, `sciclaw status`, and `sciclaw models status`.
+6. Confirm Discord reconnects and execute a narrow live canary in the intended routed workspace.
+
+Do not overwrite configuration, workspace state, credentials, routing, or memory during upgrade.
+
+### Existing workspace guidance refresh
+
+Onboarding does not overwrite an existing workspace `AGENTS.md`. For this release, inspect the active DEB guidance at `/home/ernie/Dropbox/sciclaw/deb-sciclaw/AGENTS.md` after taking a timestamped backup. If it contains the obsolete image-generation sentence, replace only that sentence with the new `image-generation` skill routing from the installed workspace template. Show the exact diff, verify the obsolete wording is absent, and preserve every unrelated workspace instruction. Do not replace the whole file.
+
+Confirm the routed DEB workspace contains the released `skills/image-generation/SKILL.md`. If it is missing, use the released SciClaw skill installation/doctor repair path; do not copy it from a development checkout.
+
+## Imagery-routing acceptance
+
+For image-generation changes, test distinct products in a fresh DEB session:
+
+1. standalone illustration;
+2. visual asset intended for a slide;
+3. editable PowerPoint improvement;
+4. complete image-generated 16:9 slide using supplied PowerPoint content.
+
+The complete-slide case must retain an action title, concise audience-facing wording, an integrated exhibit or analogy, and a clear takeaway. It must not silently return a wordless illustration or switch to editable PowerPoint.
+
+## Rollback
+
+Record the previous formula version and service state before deployment. If the canary fails, restore the prior Brew version using the documented contract, refresh the service, and verify gateway recovery. Do not repair a failed release with a hot-copied binary.

--- a/.gitignore
+++ b/.gitignore
@@ -75,7 +75,11 @@ auth.json
 
 # Local agent scratch
 .agent/
-.agents/
+.agents/*
+!.agents/skills/
+.agents/skills/*
+!.agents/skills/ship-job/
+!.agents/skills/ship-job/**
 .cache/
 .claude/
 .factory/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository agent guidance
+
+For end-to-end implementation and pull-request work, use the vendored repository skill at `.agents/skills/ship-job/SKILL.md`. Read it completely before changing files, and use `.agents/skills/ship-job/references/sciclaw-release.md` for any separately authorized merge, release, Homebrew, or Data3 deployment operation.
+
+Repository-local guidance takes precedence over similarly named user-level skill copies for work in this repository.

--- a/cmd/picoclaw/main.go
+++ b/cmd/picoclaw/main.go
@@ -82,6 +82,7 @@ var baselineScienceSkillNames = []string{
 	"quarto-authoring",
 	"pandoc-docx",
 	"imagemagick",
+	"image-generation",
 	"beautiful-mermaid",
 	"explainer-site",
 	"experiment-provenance",

--- a/docs/issues/gpt55-image-generation-rfc.md
+++ b/docs/issues/gpt55-image-generation-rfc.md
@@ -208,7 +208,7 @@ Files (expected):
 
 - `pkg/tools/generate_image.go` (+ tests)
 - Register in `pkg/agent/loop.go` `createToolRegistry`
-- `skills/image-gen/SKILL.md` (routing + provenance notes)
+- `skills/image-generation/SKILL.md` (final-artifact routing)
 - AGENTS.md baseline skill bullet
 - Config knobs (optional): enable flag, default model `gpt-image-2`, default size/quality, output dir
 
@@ -264,7 +264,7 @@ Only after Phase 0 proves Codex or API-key Responses works:
 
 1. **OAuth vs API key:** Can Codex backend host `image_generation` for sciClaw OAuth users? Unknown until smoke-tested.
 2. **Cost / abuse:** Image gen is expensive; need enable flag + maybe per-workspace allowlist.
-3. **Scientific integrity:** Generated illustrations must not be presented as real experimental data. Skill copy must say so.
+3. **Final-artifact routing:** Image generation must preserve the requested product. A standalone image, a visual asset for a larger artifact, an editable PowerPoint, and a complete image-generated slide are distinct outputs and must not be substituted for one another.
 4. **Vendor SDK age:** Vendored `openai-go/v3` documents older GPT Image models in some comments; Image API may still accept `gpt-image-2` via raw HTTP even if SDK enums lag. Prefer thin HTTP client in the tool (like `WeatherForecastTool`) or bump vendor.
 5. **PHI mode:** Local models cannot call OpenAI image APIs; tool must no-op/error clearly in PHI mode.
 6. **Cursor skill confusion:** Higgsfield / GenerateImage skills live in the IDE, not sciClaw. Document that they are out of scope for runtime chat.

--- a/docs/ops/correspondence-image-slide-artifact-routing.md
+++ b/docs/ops/correspondence-image-slide-artifact-routing.md
@@ -1,0 +1,116 @@
+# Image-generated slide artifact routing closeout
+
+## Answer first
+
+Ready for independent review in draft PR [#128](https://github.com/drpedapati/sciclaw/pull/128). The implementation is committed and pushed; merge, release, Homebrew publication, and Data3 deployment have not been performed.
+
+## What changed
+
+SciClaw now routes image generation by the requested final product instead of allowing tool salience to switch between a wordless illustration and an editable PowerPoint. The obsolete “real experimental data” warning was removed from runtime guidance, workspace templates, and the image-generation RFC policy. A built-in `image-generation` skill distinguishes four products: standalone image, visual asset for another artifact, editable presentation, and complete worded image-generated slide.
+
+The complete-slide contract encodes the successful DEB stress-capacity pattern: 16:9 composition, action title, concise audience-facing wording, integrated exhibit or visual analogy, and clear takeaway. Provider image transport, persistence, and Discord attachment code are unchanged.
+
+The repository now vendors `.agents/skills/ship-job/`, and root `AGENTS.md` points repository work to that copy. Its SciClaw continuation gates merge, versioning, release, Homebrew deployment, surgical DEB workspace guidance refresh, canary verification, and rollback.
+
+## Repository position
+
+- Repository: `https://github.com/drpedapati/sciclaw`
+- Worktree: `/Users/ernie/Developer/sciclaw/.worktrees/image-slide-artifact-routing`
+- Branch: `codex/image-slide-artifact-routing`
+- Base: `main` at `8b9a9df8670e93ef5e233aa2c2ad5cc7bc7a7743`
+- Reviewed implementation commit: `8d3cae4c`
+- Pull request: [#128](https://github.com/drpedapati/sciclaw/pull/128)
+
+This correspondence is a packet-only follow-up to the reviewed implementation commit. Review the current PR head to include this document.
+
+## Merge train
+
+One car: PR #128, `main` → `codex/image-slide-artifact-routing`. It has no branch or PR prerequisite. Safe order is review and green CI, then an explicitly authorized merge. Release and deployment follow only after that merge.
+
+## Verification
+
+- `go test ./pkg/agent ./pkg/providers ./pkg/workspacetpl/...` — passed.
+- `go test ./... -count=1` — passed sequentially across all packages.
+- `go vet ./...` — passed.
+- `go build ./cmd/picoclaw` — passed.
+- `git diff --check` — passed.
+- `uv run --with pyyaml python .../quick_validate.py .agents/skills/ship-job` — valid.
+- `uv run --with pyyaml python .../quick_validate.py skills/image-generation` — valid.
+- Independent standards review — initial duplication concern fixed; re-review found no material findings.
+- Independent spec review — DEB refresh, academic hierarchy, and routing-test gaps fixed; re-review found no material gaps.
+
+One timing-sensitive binary-inspection test was killed while four Go workloads ran concurrently. The isolated test passed, and the complete suite then passed sequentially. This was treated as resource contention, not hidden as a green first run.
+
+## Limits
+
+- No merge, tag, GitHub release, Homebrew tap update, or deployment has occurred.
+- Live four-mode DEB acceptance requires the released binary and refreshed routed workspace, so it remains a post-release canary.
+- The provider does not persist an internal rewritten image prompt; this change does not claim prompt-level reproducibility beyond saved user/session context.
+
+## Next safe action
+
+Run the independent GitHub review below against the current PR head and close CI. If no material findings remain, request explicit merge authorization. After merge, use `.agents/skills/ship-job/references/sciclaw-release.md` for a separately authorized release and Data3 deployment.
+
+## Independent review prompt
+
+```text
+Act as an independent senior engineer reviewing a proposed SciClaw change. Do not trust the implementer's summary as proof. Inspect the repository, exact PR diff, tests, prompt assembly, skills, packaging, and cited evidence yourself.
+
+When finished, submit findings on the pull request as a GitHub review. Approve only if no material findings remain; request changes for merge blockers; comment when evidence is incomplete. Do not merge, push fixes, or resolve your own findings.
+
+Repository: drpedapati/sciclaw — https://github.com/drpedapati/sciclaw
+Pull request: #128 — https://github.com/drpedapati/sciclaw/pull/128
+Base branch and commit: main at 8b9a9df8670e93ef5e233aa2c2ad5cc7bc7a7743
+Head branch: codex/image-slide-artifact-routing; inspect the current PR head
+Worktree: /Users/ernie/Developer/sciclaw/.worktrees/image-slide-artifact-routing
+
+Job requested:
+Vendor the ship-job development skill inside SciClaw and point repository guidance to it. Remove the misleading generated-image provenance warning. Preserve working provider transport. Route standalone images, slide assets, editable PowerPoint, and complete worded image-generated slides as distinct products. Complete-slide mode must encode the successful DEB stress-capacity communication hierarchy. Prepare the verified draft PR and a gated Brew/Data3 continuation without merging or deploying.
+
+Material constraints:
+- No provider image transport, media persistence, or Discord attachment rewrite.
+- No merge, release, Homebrew mutation, or production deployment in this PR run.
+- Existing DEB guidance must be refreshed surgically after release; unrelated workspace instructions must survive.
+
+Implemented design:
+The runtime hosted-tool note and workspace template route to one canonical built-in image-generation skill. That skill owns the detailed four-product contract and presentation hierarchy. Baseline onboarding installs it. Negative regression tests prevent restoration of the removed warning and assert all four routes. A repo-local ship skill owns PR closeout and a separately gated SciClaw release continuation.
+
+Changed-file map:
+- pkg/agent/loop.go: concise hosted-tool routing pointer.
+- pkg/agent/context_test.go: prompt, template, and canonical-skill regressions.
+- skills/image-generation/SKILL.md: four-product source of truth.
+- cmd/picoclaw/main.go: baseline skill installation.
+- pkg/workspacetpl/templates/workspace/AGENTS.md: workspace routing pointer.
+- docs/issues/gpt55-image-generation-rfc.md: replace obsolete policy.
+- .agents/skills/ship-job/** and AGENTS.md: vendored development workflow and pointer.
+- .gitignore: allow only the vendored ship skill beneath otherwise local `.agents` state.
+
+Claims requiring independent verification:
+1. Runtime/template/skill guidance no longer contains the obsolete warning except negative test literals.
+2. All four requested artifact modes, academic hierarchy, 16:9 complete-slide contract, and DEB reference are protected by meaningful tests.
+3. Provider transport and outbound attachment behavior are unchanged.
+4. Existing DEB workspace remediation is bounded, diff-verified, and release-gated.
+
+Tests reported:
+- go test ./... -count=1 — pass
+- go vet ./... — pass
+- go build ./cmd/picoclaw — pass
+- git diff --check — pass
+- both SKILL.md packages pass quick_validate.py
+
+External ground truth:
+The DEB Discord thread produced a successful complete image-generated stress-capacity slide only after the user explicitly distinguished it from both a wordless conceptual image and an editable PowerPoint. The implementation uses that communication hierarchy as a qualitative reference, not a pixel snapshot.
+
+Known limitations:
+- Live DEB four-mode acceptance is a post-release canary.
+- Internal provider-rewritten image prompts are not persisted.
+
+Review tasks:
+1. Confirm the diff matches requested behavior without broader changes.
+2. Flag dead code, dual policies, or leftovers from earlier attempts.
+3. Trace runtime prompt assembly and baseline skill installation.
+4. Check failure modes, workspace migration safety, packaging, and rollback.
+5. Confirm tests fail for old behavior and cover important negatives.
+6. Reproduce critical claims where practical.
+7. Report findings by severity with file/line references.
+```

--- a/pkg/agent/context_test.go
+++ b/pkg/agent/context_test.go
@@ -69,8 +69,15 @@ func TestImageGenerationSkillProtectsArtifactRoutes(t *testing.T) {
 		"### Editable presentation",
 		"### Complete image-generated slide",
 		"finished 16:9 slide as one image",
-		"read and follow the installed presentation and academic-presentation skills",
+		"read and follow the installed `pptx` skill",
 		"action title stating the takeaway",
+		"concise audience-facing wording",
+		"integrated exhibit or visual analogy that carries meaning",
+		"clear implication, intervention, or “so what”",
+		"readable presentation-scale hierarchy and spacing",
+		"Use source PowerPoint content when supplied",
+		"Do not return a wordless conceptual illustration",
+		"do not reconstruct an editable PowerPoint unless asked",
 		"successful stress-capacity pattern",
 	} {
 		if !strings.Contains(text, required) {

--- a/pkg/agent/context_test.go
+++ b/pkg/agent/context_test.go
@@ -27,6 +27,61 @@ func TestBuildSystemPromptIncludesHostedToolNotes(t *testing.T) {
 	}
 }
 
+func TestCodexImageGenerationToolNotePreservesFinalArtifactContract(t *testing.T) {
+	for _, required := range []string{
+		"read and follow the `image-generation` skill",
+		"preserves the user's requested final artifact",
+	} {
+		if !strings.Contains(codexImageGenerationToolNote, required) {
+			t.Fatalf("image generation note missing %q", required)
+		}
+	}
+	if strings.Contains(strings.ToLower(codexImageGenerationToolNote), "real experimental data") {
+		t.Fatal("image generation note still contains the removed provenance warning")
+	}
+}
+
+func TestWorkspaceTemplateOmitsRemovedImageGenerationWarning(t *testing.T) {
+	templatePath := filepath.Join("..", "workspacetpl", "templates", "workspace", "AGENTS.md")
+	data, err := os.ReadFile(templatePath)
+	if err != nil {
+		t.Fatalf("read workspace AGENTS template: %v", err)
+	}
+	text := string(data)
+	if strings.Contains(strings.ToLower(text), "real experimental data") {
+		t.Fatal("workspace template still contains the removed provenance warning")
+	}
+	if !strings.Contains(text, "`image-generation`") {
+		t.Fatal("workspace template missing canonical image-generation skill routing")
+	}
+}
+
+func TestImageGenerationSkillProtectsArtifactRoutes(t *testing.T) {
+	skillPath := filepath.Join("..", "..", "skills", "image-generation", "SKILL.md")
+	data, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read image-generation skill: %v", err)
+	}
+	text := string(data)
+	for _, required := range []string{
+		"### Standalone image",
+		"### Visual asset inside another artifact",
+		"### Editable presentation",
+		"### Complete image-generated slide",
+		"finished 16:9 slide as one image",
+		"read and follow the installed presentation and academic-presentation skills",
+		"action title stating the takeaway",
+		"successful stress-capacity pattern",
+	} {
+		if !strings.Contains(text, required) {
+			t.Fatalf("image-generation skill missing %q", required)
+		}
+	}
+	if strings.Contains(strings.ToLower(text), "real experimental data") {
+		t.Fatal("image-generation skill contains the removed provenance warning")
+	}
+}
+
 func TestBuildSystemPromptUsesSciClawIdentity(t *testing.T) {
 	workspace := t.TempDir()
 	cb := NewContextBuilder(workspace)

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -166,6 +166,8 @@ type llmIterationResult struct {
 	TurnErr      error
 }
 
+const codexImageGenerationToolNote = "`image_generation` (OpenAI Responses) — generate images when requested. Before choosing the output, read and follow the `image-generation` skill so the generated media preserves the user's requested final artifact."
+
 const defaultEmptyAssistantResponse = "I completed the turn but did not produce a user-facing reply. Ask me for a summary of what was done."
 
 var errDiscordAutoArchiveTimedOut = errors.New("discord auto-archive timed out")
@@ -381,9 +383,7 @@ func NewAgentLoopWithOptions(cfg *config.Config, msgBus *bus.MessageBus, provide
 	// Hosted Responses tools are appended by CodexProvider, not the local
 	// ToolRegistry. Surface them in the prompt catalog so the model knows.
 	if _, ok := provider.(*providers.CodexProvider); ok {
-		contextBuilder.SetHostedToolNotes(
-			"`image_generation` (OpenAI Responses) — when the user asks to generate or illustrate an image, use this hosted tool. Prefer `beautiful-mermaid` for diagrams and ImageMagick for editing existing files. Do not present generated images as real experimental data.",
-		)
+		contextBuilder.SetHostedToolNotes(codexImageGenerationToolNote)
 	}
 	contextBuilder.SetVersion(Version)
 

--- a/pkg/agent/loop_test.go
+++ b/pkg/agent/loop_test.go
@@ -52,6 +52,22 @@ func (m *diagnosticMockProvider) GetDefaultModel() string {
 	return "mock-model"
 }
 
+func TestNewAgentLoopWithCodexProviderAssemblesImageGenerationRouting(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Agents.Defaults.Workspace = t.TempDir()
+	provider := providers.NewCodexProvider("test-token", "test-account")
+
+	al := NewAgentLoop(cfg, bus.NewMessageBus(), provider)
+	prompt := al.contextBuilder.BuildSystemPrompt()
+
+	if !strings.Contains(prompt, "read and follow the `image-generation` skill") {
+		t.Fatal("assembled Codex prompt missing canonical image-generation skill routing")
+	}
+	if strings.Contains(strings.ToLower(prompt), "real experimental data") {
+		t.Fatal("assembled Codex prompt contains the removed provenance warning")
+	}
+}
+
 func TestLocalTurnDiagnostics_RecordLLMResponseTracksFallbacks(t *testing.T) {
 	diag := newLocalTurnDiagnostics()
 	diag.recordLLMResponse(1500*time.Millisecond, &providers.LLMResponse{

--- a/pkg/workspacetpl/templates/workspace/AGENTS.md
+++ b/pkg/workspacetpl/templates/workspace/AGENTS.md
@@ -55,7 +55,8 @@ Treat them as a starting pack, not a fixed identity. Keep, remove, or extend as 
 - `quarto-authoring`: reproducible manuscript rendering
 - `pandoc-docx`: clean first-draft Word generation from Markdown (bundled NIH template auto-applied)
 - `imagemagick`: reproducible image preprocessing (resize/crop/convert/DPI normalization)
-- OpenAI image generation (Codex/Responses `image_generation` tool): use when the user asks to generate or illustrate an image in chat. Do not present generated images as real experimental data. Prefer `beautiful-mermaid` for diagrams and `imagemagick` for editing existing files.
+- OpenAI image generation (Codex/Responses `image_generation` tool): read and follow the `image-generation` skill before choosing the output so generated media preserves the user's requested final artifact.
+- `image-generation`: final-artifact routing for standalone images, visual assets, editable presentations, and complete image-generated slides
 - `beautiful-mermaid`: diagram quality and export consistency
 - `explainer-site`: deep-dive, educational single-page explainer site creation
 - `experiment-provenance`: claim-to-artifact traceability

--- a/skills/image-generation/SKILL.md
+++ b/skills/image-generation/SKILL.md
@@ -25,7 +25,7 @@ Read and follow the presentation skills. Build or modify the PowerPoint and keep
 
 Generate the finished 16:9 slide as one image. Use source PowerPoint content when supplied, but do not reconstruct an editable PowerPoint unless asked.
 
-Before generation, read and follow the installed presentation and academic-presentation skills. Their communication hierarchy governs the slide: argument and audience-facing content come before layout, and layout comes before aesthetics. Image generation is the rendering method, not a replacement for presentation reasoning.
+Before generation, read and follow the installed `pptx` skill. Its presentation communication hierarchy governs the slide: argument and audience-facing content come before layout, and layout comes before aesthetics. Image generation is the rendering method, not a replacement for presentation reasoning.
 
 The generated slide must contain:
 

--- a/skills/image-generation/SKILL.md
+++ b/skills/image-generation/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: image-generation
+description: Generate a standalone image, a visual asset for another artifact, or a complete image-rendered presentation slide. Use when the user asks to generate, illustrate, visualize, make an image for a slide, improve a presentation with generated imagery, or create an image-generated slide. Preserve the explicitly requested output format.
+---
+
+# Image generation
+
+Identify the final deliverable before generating. Do not switch product types because another tool or skill is available.
+
+## Route the request
+
+### Standalone image
+
+Generate and attach the requested image.
+
+### Visual asset inside another artifact
+
+Generate the illustration, diagram, texture, or analogy for later composition. Keep the parent document or presentation as the final deliverable. Follow its governing skill.
+
+### Editable presentation
+
+Read and follow the presentation skills. Build or modify the PowerPoint and keep required content editable. Use generated imagery only as an integrated exhibit when useful.
+
+### Complete image-generated slide
+
+Generate the finished 16:9 slide as one image. Use source PowerPoint content when supplied, but do not reconstruct an editable PowerPoint unless asked.
+
+Before generation, read and follow the installed presentation and academic-presentation skills. Their communication hierarchy governs the slide: argument and audience-facing content come before layout, and layout comes before aesthetics. Image generation is the rendering method, not a replacement for presentation reasoning.
+
+The generated slide must contain:
+
+1. an action title stating the takeaway;
+2. one coherent argument or explanatory sequence;
+3. concise audience-facing wording;
+4. an integrated exhibit or visual analogy that carries meaning;
+5. a clear implication, intervention, or “so what”;
+6. readable presentation-scale hierarchy and spacing.
+
+Do not return a wordless conceptual illustration when the user requested a slide. Do not add provenance labels or generation disclaimers unless the user explicitly requests them.
+
+## Resolve common wording
+
+| User request | Deliverable |
+| --- | --- |
+| “Generate an image” | Standalone image |
+| “Generate an image for this slide” | Visual asset for composition |
+| “Improve this PowerPoint visually and keep it editable” | Editable PowerPoint |
+| “Make an image-generated slide” | Complete worded slide image |
+| “Use this PowerPoint's content to make an image-generated slide” | Read the PowerPoint, then generate the complete worded slide image |
+
+When wording remains genuinely ambiguous, infer from the most specific requested noun and recent user correction. Ask only if the choice would materially change the deliverable and cannot be inferred.
+
+## Reference behavior
+
+The successful stress-capacity pattern is the qualitative reference: a presentation-ready action title, a three-stage explanation, an integrated capacity/overflow analogy, and a de-escalation takeaway composed as one finished slide image. Reuse the communication hierarchy, not the literal artwork.


### PR DESCRIPTION
## Outcome

Routes image generation by the requested final artifact and removes the misleading provenance warning that caused wordless conceptual illustrations. Vendors the repository-local ship workflow and adds a gated SciClaw Brew/Data3 continuation.

## Architecture

The hosted-tool note and workspace template now point to one canonical built-in `image-generation` skill. It distinguishes standalone images, visual assets, editable presentations, and complete worded image-generated slides. Provider transport and Discord attachment code are unchanged.

## Verification

- `go test ./... -count=1`
- `go vet ./...`
- `go build ./cmd/picoclaw`
- `git diff --check`
- both vendored skills pass `quick_validate.py`
- independent standards/spec re-review: no material findings

## Cleanup

Collapsed duplicated routing policy into the `image-generation` skill; runtime and template are concise pointers. No provider fallback or parallel implementation was added.

## Review packet

[`docs/ops/correspondence-image-slide-artifact-routing.md`](https://github.com/drpedapati/sciclaw/blob/codex/image-slide-artifact-routing/docs/ops/correspondence-image-slide-artifact-routing.md) contains the complete evidence and independent-review prompt.

## Limits and rollback

No merge, tag, release, Homebrew update, or deployment has occurred. Revert this PR to restore prior prompt/skill behavior. Live DEB four-mode acceptance is a post-release canary.