### PR TITLE
docs: announce v0.3.9 image artifact routing

### DIFF
--- a/docs/blog.html
+++ b/docs/blog.html
@@ -197,6 +197,27 @@
 <main>
 
 <!-- ============================================================ -->
+<!-- JUL 17: ARTIFACT-AWARE IMAGE ROUTING                         -->
+<!-- ============================================================ -->
+
+<article class="entry" id="entry-2026-07-17-image-routing">
+  <div class="entry-header">
+    <span class="entry-date">2026-07-17</span>
+    <span class="entry-title">Image Generation Now Preserves the Deliverable</span>
+  </div>
+
+  <div class="section">
+    <h3>What shipped</h3>
+    <p>sciClaw <code>v0.3.9</code> routes image requests by the final artifact: standalone image, visual asset for another artifact, editable PowerPoint, or complete image-generated 16:9 slide.</p>
+    <p>For a complete slide, the argument and audience-facing content now govern the output. Generated imagery can carry an analogy or exhibit, but it no longer replaces the action title, concise explanation, and clear takeaway.</p>
+  </div>
+
+  <div class="callout">
+    <strong>Upgrade:</strong> <code>brew update && brew upgrade sciclaw</code>, then <code>sciclaw service refresh</code>. Release: <a href="https://github.com/drpedapati/sciclaw/releases/tag/v0.3.9">v0.3.9</a>.
+  </div>
+</article>
+
+<!-- ============================================================ -->
 <!-- JUL 11: GPT-5.6 LUNA ON CODEX OAUTH                          -->
 <!-- ============================================================ -->
 

--- a/docs/blog.html
+++ b/docs/blog.html
@@ -213,7 +213,7 @@
   </div>
 
   <div class="callout">
-    <strong>Upgrade:</strong> <code>brew update && brew upgrade sciclaw</code>, then <code>sciclaw service refresh</code>. Release: <a href="https://github.com/drpedapati/sciclaw/releases/tag/v0.3.9">v0.3.9</a>.
+    <strong>Upgrade:</strong> <code>brew update && brew upgrade sciclaw</code>, run <code>sciclaw doctor --fix</code> to install the new baseline skill, then <code>sciclaw service refresh</code>. Existing workspace guidance is preserved: if <code>AGENTS.md</code> still contains “Do not present generated images as real experimental data,” replace that image-generation bullet with the canonical instruction to read and follow the <code>image-generation</code> skill. Release: <a href="https://github.com/drpedapati/sciclaw/releases/tag/v0.3.9">v0.3.9</a>.
   </div>
 </article>
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -250,17 +250,38 @@
           <div class="track">
             <strong>Stable channel</strong>
             <code>brew install sciclaw</code>
-            <div class="meta">Production track. Current public stable: <strong>v0.3.8</strong>.</div>
+            <div class="meta">Production track. Current public stable: <strong>v0.3.9</strong>.</div>
           </div>
           <div class="track">
             <strong>Dev channel</strong>
             <code>brew install sciclaw-dev</code>
-            <div class="meta">Preview track for upcoming features and fixes. Current preview: <strong>v0.3.8</strong> (stable).</div>
+            <div class="meta">Preview track for upcoming features and fixes. Current preview: <strong>v0.3.9</strong> (stable).</div>
           </div>
         </div>
       </section>
 
       <section class="timeline">
+
+        <!-- v0.3.9 -->
+        <article class="item">
+          <div class="item-head">
+            <div class="tagline">
+              <span class="tag stable">stable</span>
+              <span class="rel">v0.3.9</span>
+            </div>
+            <span class="date">July 17, 2026</span>
+          </div>
+          <ul>
+            <li><strong>Artifact-aware imagery:</strong> image generation now preserves whether the requested product is a standalone image, a slide asset, an editable PowerPoint, or a complete worded 16:9 slide.</li>
+            <li><strong>Presentation hierarchy:</strong> complete generated slides prioritize the argument, audience-facing wording, integrated exhibit, and takeaway instead of substituting a wordless conceptual illustration.</li>
+            <li><strong>Workspace repair:</strong> the new built-in <code>image-generation</code> skill is installed and checked with the baseline science skills.</li>
+          </ul>
+          <div class="links">
+            <a href="https://github.com/drpedapati/sciclaw/releases/tag/v0.3.9" target="_blank" rel="noopener noreferrer">Release</a>
+            <a href="https://github.com/drpedapati/sciclaw/compare/v0.3.8...v0.3.9" target="_blank" rel="noopener noreferrer">Compare</a>
+            <a href="blog.html#entry-2026-07-17-image-routing">Blog</a>
+          </div>
+        </article>
 
         <!-- v0.3.8 -->
         <article class="item">

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -274,7 +274,7 @@
           <ul>
             <li><strong>Artifact-aware imagery:</strong> image generation now preserves whether the requested product is a standalone image, a slide asset, an editable PowerPoint, or a complete worded 16:9 slide.</li>
             <li><strong>Presentation hierarchy:</strong> complete generated slides prioritize the argument, audience-facing wording, integrated exhibit, and takeaway instead of substituting a wordless conceptual illustration.</li>
-            <li><strong>Workspace repair:</strong> the new built-in <code>image-generation</code> skill is installed and checked with the baseline science skills.</li>
+            <li><strong>Workspace repair:</strong> the new built-in <code>image-generation</code> skill is installed during onboarding and added to existing workspaces by <code>sciclaw doctor --fix</code>.</li>
           </ul>
           <div class="links">
             <a href="https://github.com/drpedapati/sciclaw/releases/tag/v0.3.9" target="_blank" rel="noopener noreferrer">Release</a>

--- a/docs/v0.3.9-announcement.md
+++ b/docs/v0.3.9-announcement.md
@@ -7,6 +7,7 @@ sciClaw v0.3.9 is out.
 Image generation now preserves the requested deliverable: standalone art, slide asset, editable PowerPoint, or a complete worded 16:9 slide. The argument leads; generated imagery supports it.
 
 brew update && brew upgrade sciclaw
+sciclaw doctor --fix
 sciclaw service refresh
 
 https://github.com/drpedapati/sciclaw/releases/tag/v0.3.9
@@ -18,4 +19,5 @@ https://github.com/drpedapati/sciclaw/releases/tag/v0.3.9
 - Built-in `image-generation` routing skill with four explicit artifact modes
 - Complete-slide route requires an action title, concise wording, integrated exhibit or analogy, and a clear takeaway
 - Removes the obsolete image-generation provenance warning from runtime and workspace guidance
+- Existing workspaces: after `doctor --fix`, replace the old “real experimental data” image-generation sentence in `AGENTS.md` with the canonical instruction to follow the `image-generation` skill
 - PR: https://github.com/drpedapati/sciclaw/pull/128

--- a/docs/v0.3.9-announcement.md
+++ b/docs/v0.3.9-announcement.md
@@ -1,0 +1,21 @@
+# sciClaw v0.3.9 Announcement
+
+## Tweet
+
+sciClaw v0.3.9 is out.
+
+Image generation now preserves the requested deliverable: standalone art, slide asset, editable PowerPoint, or a complete worded 16:9 slide. The argument leads; generated imagery supports it.
+
+brew update && brew upgrade sciclaw
+sciclaw service refresh
+
+https://github.com/drpedapati/sciclaw/releases/tag/v0.3.9
+
+---
+
+## Short notes
+
+- Built-in `image-generation` routing skill with four explicit artifact modes
+- Complete-slide route requires an action title, concise wording, integrated exhibit or analogy, and a clear takeaway
+- Removes the obsolete image-generation provenance warning from runtime and workspace guidance
+- PR: https://github.com/drpedapati/sciclaw/pull/128


### PR DESCRIPTION
Release-train documentation for the user-visible image artifact routing change merged in #128. Updates the stable channel, changelog, blog, and short announcement before tagging v0.3.9.